### PR TITLE
lock react-bootstrap version to avoid buggy deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix save error when adding multiple times within a day (UICAL-6)
 * Filter events by date (UICAL-11)
 * Show event details on click (UICAL-12)
+* Lock react-bootstrap to v0.32.1 to avoid buggy babel-runtime 7.0.0-beta.42 dep. Refs FOLIO-1425.
 
 ## [1.0.1] (2018.08.02)
 * Rethink calendar ui

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@folio/react-intl-safe-html": "^1.0.1",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.19",
+    "@folio/stripes-smart-components": "^1.4.28",
     "css-loader": "^0.28.11",
     "dateformat": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-core": "^2.10.2",
     "react": "*",
-    "react-bootstrap": "^0.32.0",
+    "react-bootstrap": "0.32.1",
     "react-dom": "^16.3.0",
     "react-intl": "^2.4.0",
     "react-router-dom": "^4.0.0"


### PR DESCRIPTION
react-bootstrap >0.32.1 introduces a dependency on babel-runtime
^7.0.0-beta.42 that is incompatible with other modules in our system and
breaks the build. Locking onto v0.32.1 resolves the issue. Mad props to
@marcjohnson-kint for diagnosing this.

Refs [FOLIO-1425](https://issues.folio.org/browse/FOLIO-1425)