### PR TITLE
remove copy-and-pasted translation key

### DIFF
--- a/settings/index.js
+++ b/settings/index.js
@@ -8,7 +8,7 @@ import LibraryHours from './LibraryHours';
 const pages = [
     {
         route: 'library-hours',
-        labelKey: 'ui-calendar.settings.service_points',
+        labelKey: 'ui-calendar.settings.library_hours',
         component: LibraryHours,
     }
 ];

--- a/translations/ui-calendar/en.json
+++ b/translations/ui-calendar/en.json
@@ -22,7 +22,6 @@
   "settings.openingTime": "Opening time",
   "settings.calendar": "Calendar",
   "settings.library_hours": "Library Hours",
-  "settings.service_points": "Service Points",
   "settings.openingPeriodStart" : "Valid From",
   "settings.openingPeriodEnd" : "Valid To",
   "settings.description_type" : "Type",


### PR DESCRIPTION
Use the correct translation key: this is library hours, not organization
service points.