### PR TITLE
convert to a settings-only app for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "index.js",
   "stripes": {
-    "type": "app",
+    "type": "settings",
     "displayName": "ui-calendar.meta.title",
     "route": "/calendar",
     "hasSettings": true,


### PR DESCRIPTION
Per @ibendermonguz, the app-icon in the nav bar should be removed for
now since this app is still under development. Converting it to a
settings-only app by changing its `stripes.type` to `settings` is the
easiest way to achieve this.