### PR TITLE
UICAL-46 Dependency/import updates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
   "dependencies": {
     "@folio/react-big-calendar": "^1.0.2-pre.1",
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "^4.2.2000575",
     "css-loader": "^0.28.11",
     "dateformat": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "2.0.5-alpha.1",
+  "version": "2.0.5-pre.1",
   "description": "Opening hours",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {
@@ -112,7 +112,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/react-big-calendar": "^1.0.2-alpha.1",
+    "@folio/react-big-calendar": "^1.0.2-pre.1",
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^4.2.2000575",
     "css-loader": "^0.28.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "2.0.5-pre.1",
+  "version": "2.0.5",
   "description": "Opening hours",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {
@@ -112,7 +112,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/react-big-calendar": "^1.0.2-pre.1",
+    "@folio/react-big-calendar": "^1.0.2",
     "@folio/react-intl-safe-html": "^1.0.2",
     "css-loader": "^0.28.11",
     "dateformat": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/react-big-calendar": "^1.0.2",
+    "@folio/react-big-calendar": "^2.0.0",
     "@folio/react-intl-safe-html": "^1.0.2",
     "css-loader": "^0.28.11",
     "dateformat": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "2.0.4",
+  "version": "2.0.5-alpha.1",
   "description": "Opening hours",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {
@@ -112,7 +112,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/react-big-calendar": "^1.0.1",
+    "@folio/react-big-calendar": "^1.0.2-alpha.1",
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^4.2.2000575",
     "css-loader": "^0.28.11",

--- a/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
-import Button from '@folio/stripes-components/lib/Button';
-import { Col, Row } from '@folio/stripes-components/lib/LayoutGrid';
-import Checkbox from '@folio/stripes-components/lib/Checkbox';
-import Datepicker from '@folio/stripes-components/lib/Datepicker/Datepicker';
-import Textfield from '@folio/stripes-components/lib/TextField';
-import List from '@folio/stripes-components/lib/List';
-import Timepicker from '@folio/stripes-components/lib/Timepicker';
+import {
+  Button,
+  Col,
+  Row,
+  Checkbox,
+  Datepicker,
+  TextField,
+  List,
+  Timepicker
+} from '@folio/stripes/components';
 import CalendarUtils from '../../CalendarUtils';
 
 class ExceptionalPeriodEditor extends React.Component {
@@ -179,7 +182,7 @@ class ExceptionalPeriodEditor extends React.Component {
 
       const nameField = <Field
         name="item.periodName"
-        component={Textfield}
+        component={TextField}
         label={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
         onChange={this.setName}
         required

--- a/settings/OpeningPeriodForm/BigCalendarWrapper.js
+++ b/settings/OpeningPeriodForm/BigCalendarWrapper.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
-import withDragAndDrop from '@folio/react-big-calendar/src/addons/dragAndDrop';
+import withDragAndDrop from '@folio/react-big-calendar/lib/addons/dragAndDrop';
 import CalendarUtils from '../../CalendarUtils';
 
 BigCalendar.setLocalizer(BigCalendar.momentLocalizer(moment));

--- a/settings/ServicePointDetails.js
+++ b/settings/ServicePointDetails.js
@@ -11,7 +11,7 @@ import {
   Row
 } from '@folio/stripes/components';
 import moment from 'moment';
-import BigCalendar from '@folio/react-big-calendar/src';
+import BigCalendar from '@folio/react-big-calendar/lib';
 import OpeningPeriodFormWrapper from './OpeningPeriodForm/OpeningPeriodFormWrapper';
 import ErrorBoundary from '../ErrorBoundary';
 import CalendarUtils from '../CalendarUtils';


### PR DESCRIPTION
In conjunction with PR [# 18](https://github.com/folio-org/react-big-calendar/pull/18) for `react-big-calendar` to move its build process to a pre-publish step, a few of the import statements here needed to change.
In addition, a few of the `stripes-components` imports were conformed to work with `stripes v1.0.0` setup - 
`from '@folio/stripes/components'` as opposed to `from '@folio/stripes-components/lib/ ...'`
These PRs together should set `ui-calendar` up for inclusion in platform-complete.