### PR TITLE
Replace formatMessage() with <FormattedMessage>

### DIFF
--- a/CalendarUtils.js
+++ b/CalendarUtils.js
@@ -1,18 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import { FormattedMessage } from 'react-intl';
 
 class CalendarUtils extends React.Component {
-  static translate(id) {
-    return <FormattedMessage id={id} />;
-  }
-
-  static translateToString(id, intl) {
-    return intl.formatMessage({
-      id: `${id}`
-    });
-  }
-
   static convertNewPeriodToValidBackendPeriod(period, event) {
     const weekDays = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
     let weekDay = 8;

--- a/UiCalendar.js
+++ b/UiCalendar.js
@@ -1,5 +1,5 @@
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { FormattedDate, FormattedTime } from 'react-intl';
+import { injectIntl, intlShape, FormattedDate, FormattedTime, FormattedMessage } from 'react-intl';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Pane, Paneset, Row, Col } from '@folio/stripes/components';
@@ -11,6 +11,7 @@ import ErrorBoundary from './ErrorBoundary';
 
 class UiCalendar extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     resources: PropTypes.shape({
       calendarEvent: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -22,9 +23,6 @@ class UiCalendar extends React.Component {
         reset: PropTypes.func,
       }),
     }),
-    stripes: PropTypes.shape({
-      locale: PropTypes.string,
-    }).isRequired,
   };
 
   static manifest = Object.freeze({
@@ -82,6 +80,9 @@ class UiCalendar extends React.Component {
   }
 
   render() {
+    const {
+      intl: { locale }
+    } = this.props;
     const views = [
       BigCalendar.Views.MONTH,
       BigCalendar.Views.WEEK,
@@ -97,7 +98,7 @@ class UiCalendar extends React.Component {
         mappedEvent.endDate = new Date(event.endDate);
 
         const eventTitleTranslationKey = `ui-calendar.settings.event_type.${event.eventType.toLowerCase()}`;
-        const eventTitleTranslation = this.props.stripes.intl.formatMessage({ id: eventTitleTranslationKey });
+        const eventTitleTranslation = <FormattedMessage id={eventTitleTranslationKey} />;
 
         if (eventTitleTranslationKey !== eventTitleTranslation) {
           mappedEvent.eventType = eventTitleTranslation;
@@ -147,7 +148,7 @@ class UiCalendar extends React.Component {
               titleAccessor="eventType"
               views={views}
               resources={[null]}
-              culture={this.props.stripes.locale}
+              culture={locale}
               messages={messages}
               onNavigate={this.navigate}
               onView={this.changeView}
@@ -162,7 +163,7 @@ class UiCalendar extends React.Component {
             defaultWidth="fill"
             height="100%"
             fluidContentWidth
-            paneTitle={this.props.stripes.intl.formatMessage({ id: 'ui-calendar.main.eventDetails' })}
+            paneTitle={<FormattedMessage id="ui-calendar.main.eventDetails" />}
             dismissible
             onClose={this.handleClose}
           >
@@ -194,4 +195,4 @@ class UiCalendar extends React.Component {
   }
 }
 
-export default UiCalendar;
+export default injectIntl(UiCalendar);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ class CalendarRouting extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      locale: PropTypes.string.isRequired,
     }).isRequired,
     location: PropTypes.object.isRequired,
     match: PropTypes.object.isRequired,

--- a/settings/CloneSettings.js
+++ b/settings/CloneSettings.js
@@ -5,10 +5,6 @@ import { Checkbox, Headline, List, Pane } from '@folio/stripes/components';
 class CloneSettings extends React.Component {
     static propTypes = {
       onToggle: PropTypes.func.isRequired,
-      stripes: PropTypes.shape({
-        connect: PropTypes.func.isRequired,
-        intl: PropTypes.object.isRequired,
-      }).isRequired,
     };
 
     static manifest = Object.freeze({

--- a/settings/LibraryHours.js
+++ b/settings/LibraryHours.js
@@ -116,9 +116,6 @@ LibraryHours.propTypes = {
       replace: PropTypes.func,
     }),
   }).isRequired,
-  stripes: PropTypes.shape({
-    intl: PropTypes.object.isRequired,
-  }),
 };
 
 

--- a/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import RandomColor from 'randomcolor';
 import moment from 'moment';
+import { FormattedMessage } from 'react-intl';
 import {
   Button,
   PaneMenu,
@@ -14,7 +15,6 @@ import {
 } from '@folio/stripes/components';
 import ServicePointSelector from './ServicePointSelector';
 import ExceptionalPeriodEditor from './ExceptionalPeriodEditor';
-import CalendarUtils from '../../CalendarUtils';
 import ExceptionalBigCalendar from './ExceptionalBigCalendar';
 import '!style-loader!css-loader!../../css/exception-form.css';  // eslint-disable-line
 import SafeHTMLMessage from '@folio/react-intl-safe-html' ;// eslint-disable-line
@@ -23,7 +23,6 @@ class ExceptionWrapper extends React.Component {
     static propTypes = {
       entries: PropTypes.object,
       onClose: PropTypes.func.isRequired,
-      stripes: PropTypes.object,
       intl: PropTypes.object
     };
 
@@ -1002,7 +1001,7 @@ class ExceptionWrapper extends React.Component {
               buttonStyle="primary"
               onClick={() => { this.setState({ openEditor: true }); }}
             >
-              {CalendarUtils.translateToString('ui-calendar.exceptionalNewPeriod', this.props.stripes.intl)}
+              <FormattedMessage id="ui-calendar.exceptionalNewPeriod" />
             </Button>
           </div>
         </PaneMenu>;
@@ -1015,7 +1014,7 @@ class ExceptionWrapper extends React.Component {
             buttonStyle="danger"
             onClick={this.setDeleteQuestion}
           >
-            {CalendarUtils.translateToString('ui-calendar.deleteButton', this.props.stripes.intl)}
+            <FormattedMessage id="ui-calendar.deleteButton" />
           </Button>;
       }
 
@@ -1024,7 +1023,7 @@ class ExceptionWrapper extends React.Component {
           buttonStyle="primary"
           onClick={this.saveException}
         >
-          {CalendarUtils.translateToString('ui-calendar.saveButton', this.props.stripes.intl)}
+          <FormattedMessage id="ui-calendar.saveButton" />
         </Button>;
 
       const lastMenus =
@@ -1036,11 +1035,11 @@ class ExceptionWrapper extends React.Component {
       const paneTitle =
         <PaneMenu>
           <Icon icon="calendar" />
-          {CalendarUtils.translateToString('ui-calendar.settings.library_hours', this.props.stripes.intl)}
+          <FormattedMessage id="ui-calendar.settings.library_hours" />
         </PaneMenu>;
 
       const selectorPane =
-        <Pane defaultWidth="20%" paneTitle={CalendarUtils.translateToString('ui-calendar.servicePoints', this.props.stripes.intl)}>
+        <Pane defaultWidth="20%" paneTitle={<FormattedMessage id="ui-calendar.servicePoints" />}>
           <ServicePointSelector
             {...this.props}
             handleServicePointChange={this.handleServicePointChange}
@@ -1061,9 +1060,9 @@ class ExceptionWrapper extends React.Component {
       let editorPaneTittle = null;
 
       if (this.state.editor.exceptionalIds !== null && this.state.editor.exceptionalIds !== undefined) {
-        editorPaneTittle = CalendarUtils.translateToString('ui-calendar.editExceptionPeriod', this.props.stripes.intl);
+        editorPaneTittle = <FormattedMessage id="ui-calendar.editExceptionPeriod" />;
       } else {
-        editorPaneTittle = CalendarUtils.translateToString('ui-calendar.newExceptionPeriod', this.props.stripes.intl);
+        editorPaneTittle = <FormattedMessage id="ui-calendar.newExceptionPeriod" />;
       }
 
       const editorPane =
@@ -1112,7 +1111,7 @@ class ExceptionWrapper extends React.Component {
             onClick={this.closeErrorModal}
             ButtonStyle="primary"
           >
-            {CalendarUtils.translateToString('ui-calendar.close', this.props.stripes.intl)}
+            <FormattedMessage id="ui-calendar.close" />
           </Button>
         </Fragment>
       );
@@ -1125,10 +1124,10 @@ class ExceptionWrapper extends React.Component {
             dismissible
             onClose={this.closeErrorModal}
             open
-            label={CalendarUtils.translateToString('ui-calendar.saveError', this.props.stripes.intl)}
+            label={<FormattedMessage id="ui-calendar.saveError" />}
             footer={footer}
           >
-            <p>{CalendarUtils.translateToString(label, this.props.stripes.intl)}</p>
+            <p><FormattedMessage id={label} /></p>
           </Modal>;
       }
 
@@ -1143,7 +1142,7 @@ class ExceptionWrapper extends React.Component {
           <ConfirmationModal
             id="delete-confirmation"
             open={this.state.deleteQuestion}
-            heading={CalendarUtils.translateToString('ui-calendar.deleteQuestionExceptionTitle', this.props.stripes.intl)}
+            heading={<FormattedMessage id="ui-calendar.deleteQuestionExceptionTitle" />}
             message={text}
             onConfirm={() => {
               this.deleteException();
@@ -1151,7 +1150,7 @@ class ExceptionWrapper extends React.Component {
             onCancel={() => {
               this.setState({ deleteQuestion: false });
             }}
-            confirmLabel={CalendarUtils.translateToString('ui-calendar.deleteButton', this.props.stripes.intl)}
+            confirmLabel={<FormattedMessage id="ui-calendar.deleteButton" />}
           />;
       }
 
@@ -1166,7 +1165,7 @@ class ExceptionWrapper extends React.Component {
           <ConfirmationModal
             id="exite-confirmation"
             open={this.state.errorEditorClose}
-            heading={CalendarUtils.translateToString('ui-calendar.exitQuestionTitle', this.props.stripes.intl)}
+            heading={<FormattedMessage id="ui-calendar.exitQuestionTitle" />}
             message={confirmationMessageClose}
             onConfirm={() => {
               this.setState({
@@ -1194,7 +1193,7 @@ class ExceptionWrapper extends React.Component {
             onCancel={() => {
               this.setState({ errorEditorClose: false });
             }}
-            confirmLabel={CalendarUtils.translateToString('ui-calendar.closeWithoutSaving', this.props.stripes.intl)}
+            confirmLabel={<FormattedMessage id="ui-calendar.closeWithoutSaving" />}
           />;
       }
 
@@ -1209,7 +1208,7 @@ class ExceptionWrapper extends React.Component {
           <ConfirmationModal
             id="exite-confirmation"
             open={this.state.errorExceptionExit}
-            heading={CalendarUtils.translateToString('ui-calendar.exitQuestionTitle', this.props.stripes.intl)}
+            heading={<FormattedMessage id="ui-calendar.exitQuestionTitle" />}
             message={confirmationMessageExit}
             onConfirm={() => {
               return this.props.onClose();
@@ -1217,7 +1216,7 @@ class ExceptionWrapper extends React.Component {
             onCancel={() => {
               this.setState({ errorExceptionExit: false });
             }}
-            confirmLabel={CalendarUtils.translateToString('ui-calendar.exitWithoutSaving', this.props.stripes.intl)}
+            confirmLabel={<FormattedMessage id="ui-calendar.exitWithoutSaving" />}
           />;
       }
       return (

--- a/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
 import {
   Button,
   Col,
@@ -16,8 +17,6 @@ import CalendarUtils from '../../CalendarUtils';
 class ExceptionalPeriodEditor extends React.Component {
     static propTypes = {
       servicePoints: PropTypes.object.isRequired,
-      stripes: PropTypes.object,
-      intl: PropTypes.object,
       allDay: PropTypes.bool.isRequired,
       allSelector: PropTypes.object.isRequired,
       setStartDate: PropTypes.func.isRequired,
@@ -165,8 +164,7 @@ class ExceptionalPeriodEditor extends React.Component {
 
         name="item.startDate"
         component={Datepicker}
-        label={CalendarUtils.translateToString('ui-calendar.validFrom', this.props.stripes.intl)}
-        dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+        label={<FormattedMessage id="ui-calendar.validFrom" />}
         onChange={this.setStartDate}
         required
       />;
@@ -174,8 +172,7 @@ class ExceptionalPeriodEditor extends React.Component {
       const endDate = <Field
         name="item.endDate"
         component={Datepicker}
-        label={CalendarUtils.translateToString('ui-calendar.validTo', this.props.stripes.intl)}
-        dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+        label={<FormattedMessage id="ui-calendar.validTo" />}
         onChange={this.setEndDate}
         required
       />;
@@ -183,7 +180,7 @@ class ExceptionalPeriodEditor extends React.Component {
       const nameField = <Field
         name="item.periodName"
         component={TextField}
-        label={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
+        label={<FormattedMessage id="ui-calendar.name" />}
         onChange={this.setName}
         required
       />;
@@ -194,14 +191,14 @@ class ExceptionalPeriodEditor extends React.Component {
           <Button
             onClick={() => { this.allSelectorHandle(false); }}
           >
-            {CalendarUtils.translateToString('ui-calendar.deselectAll', this.props.stripes.intl)}
+            <FormattedMessage id="ui-calendar.deselectAll" />
           </Button>;
       } else {
         allSelector =
           <Button
             onClick={() => { this.allSelectorHandle(true); }}
           >
-            {CalendarUtils.translateToString('ui-calendar.selectAll', this.props.stripes.intl)}
+            <FormattedMessage id="ui-calendar.selectAll" />
           </Button>;
       }
 
@@ -215,7 +212,7 @@ class ExceptionalPeriodEditor extends React.Component {
                   <Field
                     name="item.openingTime"
                     component={Timepicker}
-                    label={CalendarUtils.translateToString('ui-calendar.openingTime', this.props.stripes.intl)}
+                    label={<FormattedMessage id="ui-calendar.openingTime" />}
                     onChange={this.setStartTime}
                   />
                 </div>
@@ -227,7 +224,7 @@ class ExceptionalPeriodEditor extends React.Component {
                   <Field
                     name="item.closingTime"
                     component={Timepicker}
-                    label={CalendarUtils.translateToString('ui-calendar.closingTime', this.props.stripes.intl)}
+                    label={<FormattedMessage id="ui-calendar.closingTime" />}
                     onChange={this.setEndTime}
                   />
                 </div>
@@ -239,14 +236,14 @@ class ExceptionalPeriodEditor extends React.Component {
       let checkbox = null;
       if (this.props.editor.closed === true) {
         checkbox = <Checkbox
-          label={CalendarUtils.translateToString('ui-calendar.settings.allDay', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.settings.allDay" />}
           onChange={() => this.setAllDay()}
           checked={this.getAllday()}
           disabled
         />;
       } else {
         checkbox = <Checkbox
-          label={CalendarUtils.translateToString('ui-calendar.settings.allDay', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.settings.allDay" />}
           onChange={() => this.setAllDay()}
           checked={this.getAllday()}
         />;
@@ -273,7 +270,7 @@ class ExceptionalPeriodEditor extends React.Component {
           <Row>
             <Col>
               <div>
-                {CalendarUtils.translateToString('ui-calendar.settings.openingPeriodEnd', this.props.stripes.intl)}
+                <FormattedMessage id="ui-calendar.settings.openingPeriodEnd" />
               </div>
               <List
                 items={items}
@@ -292,7 +289,7 @@ class ExceptionalPeriodEditor extends React.Component {
             <Col>
               <Row>
                 <Checkbox
-                  label={CalendarUtils.translateToString('ui-calendar.settings.closed', this.props.stripes.intl)}
+                  label={<FormattedMessage id="ui-calendar.settings.closed" />}
                   onChange={() => this.setClosed()}
                 />
               </Row>

--- a/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -12,7 +12,6 @@ import {
   List,
   Timepicker
 } from '@folio/stripes/components';
-import CalendarUtils from '../../CalendarUtils';
 
 class ExceptionalPeriodEditor extends React.Component {
     static propTypes = {

--- a/settings/OpeningPeriodForm/BigCalendarHeader.js
+++ b/settings/OpeningPeriodForm/BigCalendarHeader.js
@@ -1,6 +1,6 @@
-import { Button, Headline, Row, Col } from '@folio/stripes/components';
 import React from 'react';
-import CalendarUtils from '../../CalendarUtils';
+import { FormattedMessage } from 'react-intl';
+import { Button, Headline, Row, Col } from '@folio/stripes/components';
 
 class BigCalendarHeader extends React.Component {
   render() {
@@ -9,16 +9,16 @@ class BigCalendarHeader extends React.Component {
         <Row>
           <Col xs={6}>
             <Headline>
-              {CalendarUtils.translate('ui-calendar.regularLibraryHoursCalendar')}
+              <FormattedMessage id="ui-calendar.regularLibraryHoursCalendar" />
             </Headline>
           </Col>
           <Col xs={6} className="new-period-buttons">
 
             <Button disabled>
-              {CalendarUtils.translate('ui-calendar.selectTemplate')}
+              <FormattedMessage id="ui-calendar.selectTemplate" />
             </Button>
             <Button disabled>
-              {CalendarUtils.translate('ui-calendar.copy')}
+              <FormattedMessage id="ui-calendar.copy" />
             </Button>
           </Col>
         </Row>

--- a/settings/OpeningPeriodForm/FromHeader.js
+++ b/settings/OpeningPeriodForm/FromHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Headline, IconButton, Row, Col } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
-import CalendarUtils from '../../CalendarUtils';
+import { FormattedMessage } from 'react-intl';
 
 class FromHeader extends React.Component {
     static propTypes = {
@@ -13,21 +13,31 @@ class FromHeader extends React.Component {
     render() {
       let disabled;
       if (this.props.modifyPeriod) {
-        disabled = <Button onClick={() => { this.props.handleDelete(); }} buttonStyle="danger">{CalendarUtils.translate('ui-calendar.deleteButton')}</Button>;
+        disabled = (
+          <Button onClick={() => { this.props.handleDelete(); }} buttonStyle="danger">
+            <FormattedMessage id="ui-calendar.deleteButton" />
+          </Button>
+        );
       } else {
-        disabled = <Button disabled onClick={() => { this.props.handleDelete(); }} buttonStyle="danger">{CalendarUtils.translate('ui-calendar.deleteButton')}</Button>;
+        disabled = (
+          <Button disabled onClick={() => { this.props.handleDelete(); }} buttonStyle="danger">
+            <FormattedMessage id="ui-calendar.deleteButton" />
+          </Button>
+        );
       }
       let title;
       if (this.props.modifyPeriod) {
-        title =
+        title = (
           <Headline size="large" margin="medium" tag="h3">
-            {CalendarUtils.translate('ui-calendar.modifyRegularLibraryValidityPeriod')}
-          </Headline>;
+            <FormattedMessage id="ui-calendar.modifyRegularLibraryValidityPeriod" />
+          </Headline>
+        );
       } else {
-        title =
+        title = (
           <Headline size="large" margin="medium" tag="h3">
-            {CalendarUtils.translate('ui-calendar.regularLibraryValidityPeriod')}
-          </Headline>;
+            <FormattedMessage id="ui-calendar.regularLibraryValidityPeriod" />
+          </Headline>
+        );
       }
 
       return (
@@ -49,8 +59,12 @@ class FromHeader extends React.Component {
             <Col sm={3} className="new-period-buttons">
 
               {disabled}
-              <Button type="submit" buttonStyle="default">{CalendarUtils.translate('ui-calendar.saveButton')}</Button>
-              <Button disabled buttonStyle="primary">{CalendarUtils.translate('ui-calendar.savesAsTemplate')}</Button>
+              <Button type="submit" buttonStyle="default">
+                <FormattedMessage id="ui-calendar.saveButton" />
+              </Button>
+              <Button disabled buttonStyle="primary">
+                <FormattedMessage id="ui-calendar.savesAsTemplate" />
+              </Button>
 
             </Col>
           </Row>

--- a/settings/OpeningPeriodForm/InputFields.js
+++ b/settings/OpeningPeriodForm/InputFields.js
@@ -1,8 +1,8 @@
 import { Datepicker, TextField, Row, Col } from '@folio/stripes/components';
 import React from 'react';
 import { Field, reduxForm } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import CalendarUtils from '../../CalendarUtils';
 
 class InputFields extends React.Component {
     static propTypes = {
@@ -10,8 +10,6 @@ class InputFields extends React.Component {
       onNameChange: PropTypes.func.isRequired,
       nameValue: PropTypes.string.isRequired,
       modifyPeriod: PropTypes.object,
-      stripes: PropTypes.object,
-      intl: PropTypes.object
     };
 
 
@@ -70,8 +68,7 @@ class InputFields extends React.Component {
         modifyStart = <Field
           name="item.startDate"
           component={Datepicker}
-          label={CalendarUtils.translateToString('ui-calendar.validFrom', this.props.stripes.intl)}
-          dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.validFrom" />}
           onChange={this.setStartDate}
           required
         />;
@@ -79,26 +76,25 @@ class InputFields extends React.Component {
         modifyEnd = <Field
           name="item.endDate"
           component={Datepicker}
-          label={CalendarUtils.translateToString('ui-calendar.validTo', this.props.stripes.intl)}
-          dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.validTo" />}
           onChange={this.setEndDate}
           required
         />;
 
         if (this.state !== null && this.state !== undefined && this.state.errorBoolean !== null && this.state.errorBoolean !== undefined && this.state.errorBoolean) {
           modifyName = <Field
-            label={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
+            label={<FormattedMessage id="ui-calendar.name" />}
             value={this.props.modifyPeriod.name || ''}
             name="periodName"
             id="input-period-name"
             component={TextField}
             onChange={this.setName}
-            error={CalendarUtils.translateToString('ui-calendar.fillIn', this.props.stripes.intl)}
+            error={<FormattedMessage id="ui-calendar.fillIn" />}
             required
           />;
         } else {
           modifyName = <Field
-            label={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
+            label={<FormattedMessage id="ui-calendar.name" />}
             value={this.props.modifyPeriod.name || ''}
             name="periodName"
             id="input-period-name"
@@ -111,8 +107,7 @@ class InputFields extends React.Component {
         modifyStart = <Field
           name="item.startDate"
           component={Datepicker}
-          label={CalendarUtils.translateToString('ui-calendar.validFrom', this.props.stripes.intl)}
-          dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.validFrom" />}
           onChange={this.setStartDate}
           required
         />;
@@ -120,8 +115,7 @@ class InputFields extends React.Component {
         modifyEnd = <Field
           name="item.endDate"
           component={Datepicker}
-          label={CalendarUtils.translateToString('ui-calendar.validTo', this.props.stripes.intl)}
-          dateFormat={CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)}
+          label={<FormattedMessage id="ui-calendar.validTo" />}
           onChange={this.setEndDate}
           required
         />;
@@ -131,19 +125,19 @@ class InputFields extends React.Component {
           modifyName =
             <Field
               name="periodName"
-              llabel={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
+              label={<FormattedMessage id="ui-calendar.name" />}
               id="input-period-name"
               onBlur={this.onBlur}
               onChange={this.setName}
               required
-              error={CalendarUtils.translateToString('ui-calendar.fillIn', this.props.stripes.intl)}
+              error={<FormattedMessage id="ui-calendar.fillIn" />}
               component={TextField}
             />;
         } else {
           modifyName =
             <Field
               name="periodName"
-              label={CalendarUtils.translateToString('ui-calendar.name', this.props.stripes.intl)}
+              label={<FormattedMessage id="ui-calendar.name" />}
               id="input-period-name"
               onBlur={this.onBlur}
               onChange={this.setName}

--- a/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
+++ b/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { FormattedMessage } from 'react-intl';
 import { Button, ConfirmationModal, Modal } from '@folio/stripes/components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import FromHeader from './FromHeader';
@@ -29,9 +30,6 @@ class OpeningPeriodFormWrapper extends React.Component {
         period: PropTypes.shape({
           POST: PropTypes.func.isRequired,
         }),
-      }),
-      stripes: PropTypes.shape({
-        intl: PropTypes.object.isRequired,
       }),
     };
 
@@ -126,14 +124,14 @@ class OpeningPeriodFormWrapper extends React.Component {
       const { parentMutator, servicePointId } = this.props;
       if ((moment(this.state.startDate).toDate() > moment(this.state.endDate).toDate()) && (moment(this.state.startDate).toDate() === moment(this.state.endDate).toDate())) {
         this.setState({
-          errorModalText: CalendarUtils.translateToString('ui-calendar.wrongStartEndDate', this.props.stripes.intl),
+          errorModalText: <FormattedMessage id="ui-calendar.wrongStartEndDate" />,
         });
         this.render();
         return null;
       }
       if (this.state.event === null || this.state.event === undefined || this.state.event.length === 0) {
         this.setState({
-          errorModalText: CalendarUtils.translateToString('ui-calendar.noEvents', this.props.stripes.intl),
+          errorModalText: <FormattedMessage id="ui-calendar.noEvents" />,
         });
         this.render();
         return null;
@@ -215,7 +213,7 @@ class OpeningPeriodFormWrapper extends React.Component {
         <ConfirmationModal
           id="delete-confirmation"
           open={confirmDelete}
-          heading={CalendarUtils.translateToString('ui-calendar.deleteQuestionTitle', this.props.stripes.intl)}
+          heading={<FormattedMessage id="ui-calendar.deleteQuestionTitle" />}
           message={confirmationMessageDelete}
           onConfirm={() => {
             this.handleDelete();
@@ -223,14 +221,14 @@ class OpeningPeriodFormWrapper extends React.Component {
           onCancel={() => {
             this.setState({ confirmDelete: false });
           }}
-          confirmLabel={CalendarUtils.translateToString('ui-calendar.deleteButton', this.props.stripes.intl)}
+          confirmLabel={<FormattedMessage id="ui-calendar.deleteButton" />}
         />;
 
       const errorExit =
         <ConfirmationModal
           id="exite-confirmation"
           open={confirmExit}
-          heading={CalendarUtils.translateToString('ui-calendar.exitQuestionTitle', this.props.stripes.intl)}
+          heading={<FormattedMessage id="ui-calendar.exitQuestionTitle" />}
           message={confirmationMessageExit}
           onConfirm={() => {
             return this.props.onClose();
@@ -238,7 +236,7 @@ class OpeningPeriodFormWrapper extends React.Component {
           onCancel={() => {
             this.setState({ confirmExit: false });
           }}
-          confirmLabel={CalendarUtils.translateToString('ui-calendar.exitWithoutSaving', this.props.stripes.intl)}
+          confirmLabel={<FormattedMessage id="ui-calendar.exitWithoutSaving" />}
         />;
       if (this.state.errorModalText !== null && this.state.errorModalText !== undefined) {
         const footer = (
@@ -247,7 +245,7 @@ class OpeningPeriodFormWrapper extends React.Component {
               onClick={this.closeErrorModal}
               ButtonStyle="primary"
             >
-              {CalendarUtils.translateToString('ui-calendar.close', this.props.stripes.intl)}
+              <FormattedMessage id="ui-calendar.close" />
             </Button>
           </Fragment>
         );
@@ -257,7 +255,7 @@ class OpeningPeriodFormWrapper extends React.Component {
             dismissible
             onClose={this.closeErrorModal}
             open
-            label={CalendarUtils.translateToString('ui-calendar.invalidData', this.props.stripes.intl)}
+            label={<FormattedMessage id="ui-calendar.invalidData" />}
             footer={footer}
           >
             <p>{this.state.errorModalText}</p>

--- a/settings/ServicePointDetails.js
+++ b/settings/ServicePointDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import {
   Button,
   Col,
@@ -14,7 +15,6 @@ import moment from 'moment';
 import BigCalendar from '@folio/react-big-calendar/lib';
 import OpeningPeriodFormWrapper from './OpeningPeriodForm/OpeningPeriodFormWrapper';
 import ErrorBoundary from '../ErrorBoundary';
-import CalendarUtils from '../CalendarUtils';
 import ExceptionWrapper from './OpenExceptionalForm/ExceptionWrapper';
 
 class ServicePointDetails extends React.Component {
@@ -94,6 +94,7 @@ class ServicePointDetails extends React.Component {
   }
 
   displayCurrentPeriod() {
+    const { intl: { formatMessage } } = this.props;
     let res;
     for (let index = 0; index < this.state.openingPeriods.length; index++) {
       const openingPeriod = this.state.openingPeriods[index];
@@ -101,8 +102,8 @@ class ServicePointDetails extends React.Component {
       const end = moment(openingPeriod.endDate, 'YYYY-MM-DD');
       if (moment() > start && moment() < end) {
         res = {
-          startDate: start.format(CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)),
-          endDate: end.format(CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)),
+          startDate: start.format(formatMessage('ui-calendar.dateFormat')),
+          endDate: end.format(formatMessage('ui-calendar.dateFormat')),
           name: openingPeriod.name,
           openingDays: openingPeriod.openingDays,
           id: openingPeriod.id
@@ -113,6 +114,7 @@ class ServicePointDetails extends React.Component {
   }
 
   displayNextPeriod() {
+    const { intl: { formatMessage } } = this.props;
     const displayPeriods = [];
     for (let index = 0; index < this.state.openingPeriods.length; index++) {
       const openingPeriod = this.state.openingPeriods[index];
@@ -121,8 +123,8 @@ class ServicePointDetails extends React.Component {
       if (!(moment() > start && moment() < end) && start > new Date()) {
         displayPeriods.push({
           id: openingPeriod.id,
-          startDate: start.format(CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)),
-          endDate: end.format(CalendarUtils.translateToString('ui-calendar.dateFormat', this.props.stripes.intl)),
+          startDate: start.format(formatMessage('ui-calendar.dateFormat')),
+          endDate: end.format(formatMessage('ui-calendar.dateFormat')),
           name: openingPeriod.name
         });
       }
@@ -176,7 +178,7 @@ class ServicePointDetails extends React.Component {
     if (this.state.currentPeriod) {
       currentP =
         <KeyValue
-          label={CalendarUtils.translate('ui-calendar.current')}
+          label={<FormattedMessage id="ui-calendar.current" />}
           value={
             <div
               className="periods"
@@ -195,43 +197,43 @@ class ServicePointDetails extends React.Component {
             <div className="seven-cols">
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.sunDayShort')}
+                  label={<FormattedMessage id="ui-calendar.sunDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[0])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.monDayShort')}
+                  label={<FormattedMessage id="ui-calendar.monDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[1])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.tueDayShort')}
+                  label={<FormattedMessage id="ui-calendar.tueDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[2])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.wedDayShort')}
+                  label={<FormattedMessage id="ui-calendar.wedDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[3])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.thuDayShort')}
+                  label={<FormattedMessage id="ui-calendar.thuDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[4])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.friDayShort')}
+                  label={<FormattedMessage id="ui-calendar.friDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[5])}
                 />
               </div>
               <div className="col-sm-1">
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.satDayShort')}
+                  label={<FormattedMessage id="ui-calendar.satDayShort" />}
                   value={this.getWeekdayOpeningHours(weekdays[6])}
                 />
               </div>
@@ -261,7 +263,7 @@ class ServicePointDetails extends React.Component {
               size="small"
               margin="large"
             >
-              {CalendarUtils.translate('ui-calendar.nextPeriod')}
+              <FormattedMessage id="ui-calendar.nextPeriod" />
             </Headline>
             <List
               items={this.state.nextPeriods}
@@ -281,22 +283,22 @@ class ServicePointDetails extends React.Component {
             <Row>
               <Col xs>
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.name')}
+                  label={<FormattedMessage id="ui-calendar.name" />}
                   value={servicePoint.name}
                 />
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.code')}
+                  label={<FormattedMessage id="ui-calendar.code" />}
                   value={servicePoint.code}
                 />
                 <KeyValue
-                  label={CalendarUtils.translate('ui-calendar.settings.locations.discoveryDisplayName')}
+                  label={<FormattedMessage id="ui-calendar.settings.locations.discoveryDisplayName" />}
                   value={servicePoint.discoveryDisplayName}
                 />
                 <Headline
                   size="small"
                   margin="large"
                 >
-                  {CalendarUtils.translate('ui-calendar.regularLibraryHours')}
+                  <FormattedMessage id="ui-calendar.regularLibraryHours" />
                 </Headline>
                 {currentP}
 
@@ -307,12 +309,12 @@ class ServicePointDetails extends React.Component {
             <Row>
               <Col xs={4}>
                 <Button onClick={() => this.clickNewPeriod()}>
-                  {CalendarUtils.translate('ui-calendar.newButton')}
+                  <FormattedMessage id="ui-calendar.newButton" />
                 </Button>
               </Col>
               <Col xs={6}>
                 <Button disabled>
-                  {CalendarUtils.translate('ui-calendar.cloneSettings')}
+                  <FormattedMessage id="ui-calendar.cloneSettings" />
                 </Button>
               </Col>
             </Row>
@@ -323,10 +325,10 @@ class ServicePointDetails extends React.Component {
                   size="small"
                   margin="large"
                 >
-                  {CalendarUtils.translate('ui-calendar.actualLibraryHours')}
+                  <FormattedMessage id="ui-calendar.actualLibraryHours" />
                 </Headline>
 
-                <p>{CalendarUtils.translate('ui-calendar.regularOpeningHoursWithExceptions')}</p>
+                <p><FormattedMessage id="ui-calendar.regularOpeningHoursWithExceptions" /></p>
                 <div className="add-exceptions-icon-wrapper">
                   <div className="icon-button">
                     <Button onClick={() => this.clickOpenExeptions()}>
@@ -335,7 +337,7 @@ class ServicePointDetails extends React.Component {
                         size="medium"
                         iconClassName="calendar-icon"
                       />
-                      {CalendarUtils.translate('ui-calendar.openCalendarExceptions')}
+                      <FormattedMessage id="ui-calendar.openCalendarExceptions" />
                     </Button>
                   </div>
                 </div>
@@ -345,7 +347,7 @@ class ServicePointDetails extends React.Component {
 
           <Layer
             isOpen={this.state.newPeriodLayer.isOpen}
-            label={this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel })}
+            label={<FormattedMessage id="stripes-core.label.editEntry" values={{ entry: this.props.entryLabel }} />}
             container={document.getElementById('ModuleContainer')}
           >
             <OpeningPeriodFormWrapper
@@ -360,7 +362,7 @@ class ServicePointDetails extends React.Component {
 
           <Layer
             isOpen={this.state.modifyPeriodLayer.isOpen}
-            label={this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel })}
+            label={<FormattedMessage id="stripes-core.label.editEntry" values={{ entry: this.props.entryLabel }} />}
             container={document.getElementById('ModuleContainer')}
           >
             <OpeningPeriodFormWrapper
@@ -374,7 +376,7 @@ class ServicePointDetails extends React.Component {
           </Layer>
           <Layer
             isOpen={this.state.openExceptions.isOpen}
-            label={this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel })}
+            label={<FormattedMessage id="stripes-core.label.editEntry" values={{ entry: this.props.entryLabel }} />}
             container={document.getElementById('ModuleContainer')}
           >
 
@@ -403,10 +405,7 @@ class ServicePointDetails extends React.Component {
 
 ServicePointDetails.propTypes = {
   initialValues: PropTypes.object,
-  stripes: PropTypes.shape({
-    intl: PropTypes.object.isRequired,
-    connect: PropTypes.func.isRequired,
-  }).isRequired,
+  intl: intlShape.isRequired,
   resources: PropTypes.shape({
     periods: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
@@ -415,4 +414,4 @@ ServicePointDetails.propTypes = {
 };
 
 
-export default ServicePointDetails;
+export default injectIntl(ServicePointDetails);

--- a/settings/ViewOpeningDay.js
+++ b/settings/ViewOpeningDay.js
@@ -2,10 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import dateFormat from 'dateformat';
-import { FormattedDate, FormattedTime } from 'react-intl';
+import { FormattedDate, FormattedTime, FormattedMessage } from 'react-intl';
 import { Row, Col } from '@folio/stripes/components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import CalendarUtils from '../CalendarUtils';
 
 function calculateTime(startTime, endTime, open, allDay) {
   if (!open) {
@@ -32,8 +31,8 @@ function ViewOpeningDay(props) {
   const openingDays = props.initialValues;
 
   const eventTypeOptions = {
-    'OPENING_DAY': CalendarUtils.translate('ui-calendar.settings.event_type.opening_day'),
-    'EXCEPTION': CalendarUtils.translate('ui-calendar.settings.event_type.exception'),
+    'OPENING_DAY': <FormattedMessage id="ui-calendar.settings.event_type.opening_day" />,
+    'EXCEPTION': <FormattedMessage id="ui-calendar.settings.event_type.exception" />,
   };
 
   return (

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
-import CalendarUtils from '../CalendarUtils';
 
 import LibraryHours from './LibraryHours';
 
@@ -13,12 +13,12 @@ const pages = [
 ];
 
 
-function getPages(pageDefinitions, props) {
+function getPages(pageDefinitions) {
   const routes = [];
   pageDefinitions.forEach((page) => {
     routes.push({
       route: page.route,
-      label: props.stripes.intl.formatMessage({ id: page.labelKey }),
+      label: <FormattedMessage id={page.labelKey} />,
       component: page.component,
     });
   });
@@ -27,6 +27,6 @@ function getPages(pageDefinitions, props) {
 
 export default props => <Settings
   {...props}
-  pages={getPages(pages, props)}
-  paneTitle={CalendarUtils.translateToString('ui-calendar.settings.calendar', props.stripes.intl)}
+  pages={getPages(pages)}
+  paneTitle={<FormattedMessage id="ui-calendar.settings.calendar" />}
 />;


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/stripes-core/pull/489

Retrieving the `intl` object from `this.context.intl` or the `stripes` god object (`stripes.intl`) is a deprecated pattern.

## Approach
- Use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to `formatMessage()`, `formatDate()`, and `formatTime()` (accompanied by `injectIntl`) when a bare string is absolutely necessary.
- Don't pass in unneeded `dateFormat` prop to `Datepicker` - it should be localized out of the box.

## Future work
- The couple of instances of `formatMessage()` I left around need to be revisited. It looks like `dateFormat` is being stored in the translation files. Moment and/or `react-intl` should handle the `dateFormat` instead.