### PR TITLE
BF-73: Fix formatMessage usage.

### DIFF
--- a/settings/ServicePointDetails.js
+++ b/settings/ServicePointDetails.js
@@ -123,8 +123,8 @@ class ServicePointDetails extends React.Component {
       if (!(moment() > start && moment() < end) && start > new Date()) {
         displayPeriods.push({
           id: openingPeriod.id,
-          startDate: start.format(formatMessage('ui-calendar.dateFormat')),
-          endDate: end.format(formatMessage('ui-calendar.dateFormat')),
+          startDate: start.format(formatMessage({ id: 'ui-calendar.dateFormat' })),
+          endDate: end.format(formatMessage({ id: 'ui-calendar.dateFormat' })),
           name: openingPeriod.name
         });
       }


### PR DESCRIPTION
After adding "Regular Library Hours" "Library Hours" pane keep loading.
h2. Steps to reproduce
# Go to "Library Hours" settings.
![screen shot 2019-01-10 at 6 51 41 pm](https://user-images.githubusercontent.com/42577309/50981128-549e6100-150b-11e9-86ca-72e4d69309c5.png)
# Add new Regular Library Hours Validity Period.
![screen shot 2019-01-10 at 6 51 21 pm](https://user-images.githubusercontent.com/42577309/50981129-55cf8e00-150b-11e9-86bb-f3ed80695e1b.png)
# "Library Hours"  can't be loaded.
![screen shot 2019-01-10 at 6 55 52 pm](https://user-images.githubusercontent.com/42577309/50981131-56682480-150b-11e9-8060-fc69be0d983a.png)


