### PR TITLE
UICAL-59 Start/end date being set as objects rather than dates.

### DIFF
--- a/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -77,12 +77,12 @@ class ExceptionalPeriodEditor extends React.Component {
     // }
 
     setStartDate(e) {
-      this.props.setStartDate(e);
+      this.props.setStartDate(e.target.value);
       // this.setModifyed;
     }
 
     setEndDate(e) {
-      this.props.setEndDate(e);
+      this.props.setEndDate(e.target.value);
       // this.setModifyed;
     }
 

--- a/settings/OpeningPeriodForm/InputFields.js
+++ b/settings/OpeningPeriodForm/InputFields.js
@@ -50,11 +50,11 @@ class InputFields extends React.Component {
     }
 
     setStartDate(e) {
-      this.props.onDateChange(true, this.parseDateToString(e));
+      this.props.onDateChange(true, this.parseDateToString(e.target.value));
     }
 
     setEndDate(e) {
-      this.props.onDateChange(false, this.parseDateToString(e));
+      this.props.onDateChange(false, this.parseDateToString(e.target.value));
     }
 
     setName(e) {


### PR DESCRIPTION
Due to a change in Datepicker, change events are now objects, so accessing the value now conforms to standard means with other form inputs: using `e.target.value` rather than `e`

https://issues.folio.org/browse/UICAL-59