### PR TITLE
FOLIO-2083: purge unused deps for security reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,8 @@
 
 * Update ui-calendar translations
 * Fix sending of incorrect model to BE (UICAL-60)
-* Add BigTest setup 
+* Add BigTest setup
+
+## 2.2.0 (IN PROGRESS)
+
+* Prune deps to remove transitive dep on js-yaml v3.7.0 via css-loader > cssnano > postcss-svgo > svgo. Refs FOLIO-2083.

--- a/package.json
+++ b/package.json
@@ -103,9 +103,6 @@
   },
   "devDependencies": {
     "@bigtest/convergence": "^1.0.0",
-    "stylelint": "^9.5.0",
-    "stylelint-config-standard": "^18.2.0",
-    "stylelint-junit-formatter": "^0.2.1",
     "@bigtest/interactor": "^0.9.2",
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",
@@ -123,27 +120,24 @@
     "react-dom": "^16.5.2",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
-    "sinon": "^7.3.2"
+    "sinon": "^7.3.2",
+    "stylelint": "^9.5.0",
+    "stylelint-config-standard": "^18.2.0",
+    "stylelint-junit-formatter": "^0.2.1"
   },
   "dependencies": {
     "@folio/react-big-calendar": "^2.0.0",
     "@folio/react-intl-safe-html": "^1.0.2",
-    "css-loader": "^0.28.11",
     "dateformat": "^2.0.0",
-    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.5",
     "moment": "^2.22.2",
-    "postcss-loader": "^2.1.6",
     "prop-types": "^15.6.1",
-    "proptypes": "^1.1.0",
-    "query-string": "^6.1.0",
     "randomcolor": "^0.5.3",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
     "react-intl": "^2.7.0",
     "redux-form": "^7.0.3",
-    "style-loader": "^0.21.0",
-    "uuid": "^3.1.0"
+    "style-loader": "^0.21.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.4.0",


### PR DESCRIPTION
Purge unused dependencies pursuant to removing the transitive dep on
js-yaml v3.7.0 via css-loader > cssnano > postcss-svgo > svgo.

Refs [FOLIO-2083](https://issues.folio.org/browse/FOLIO-2083)