### PR TITLE
UICAL-71: Add edit button for new periods.

### DIFF
--- a/css/folio-calendar.css
+++ b/css/folio-calendar.css
@@ -1,5 +1,5 @@
-.periods{
-    cursor: pointer;
+.new-period {
+   width: 100%;
 }
 
 .add-exceptions-icon-wrapper{

--- a/settings/ServicePointDetails.js
+++ b/settings/ServicePointDetails.js
@@ -9,7 +9,8 @@ import {
   KeyValue,
   Layer,
   List,
-  Row
+  Row,
+  IconButton,
 } from '@folio/stripes/components';
 import moment from 'moment';
 import BigCalendar from '@folio/react-big-calendar/lib';
@@ -283,18 +284,29 @@ class ServicePointDetails extends React.Component {
     }
     let nextPeriodDetails;
     const itemFormatter = (item) => (
-      <li>
-        <div
-          data-test-next-period-item
-          className="periods"
-          onClick={() => { this.handleSelectPeriod(item.id); }}
-          onKeyDown={() => {}}
-          role="button"
-          tabIndex={0}
-          key={item.id}
+      <li
+        data-test-next-period-item
+        key={item.id}
+      >
+        <Row
+          className="new-period"
+          between="xs"
         >
-          {item.startDate + ' - ' + item.endDate + ' (' + item.name + ')'}
-        </div>
+          <Col
+            xs={11}
+            data-test-next-period-item-label
+          >
+            {item.startDate + ' - ' + item.endDate + ' (' + item.name + ')'}
+          </Col>
+          <Col xs={1}>
+            <IconButton
+              data-test-next-period-item-edit-button
+              onClick={() => { this.handleSelectPeriod(item.id); }}
+              ariaLabel="edit period button"
+              icon="edit"
+            />
+          </Col>
+        </Row>
       </li>);
 
     if (this.state.nextPeriods && this.state.nextPeriods.length > 0) {

--- a/test/bigtest/interactors/ServicePointDetails.js
+++ b/test/bigtest/interactors/ServicePointDetails.js
@@ -7,11 +7,16 @@ import {
 
 import KeyValue from './KeyValue';
 
+@interactor class NextPeriodItem {
+  label = scoped('[data-test-next-period-item-label]');
+  editButton = scoped('[data-test-next-period-item-edit-button]');
+}
+
 @interactor class NextPeriod {
   static defaultScope = '[data-test-service-point-next-period]';
 
   header = scoped('[data-test-next-period-header]');
-  list = collection('[data-test-next-period-item]');
+  list = collection('[data-test-next-period-item]', NextPeriodItem);
 }
 
 @interactor class CurrentPeriodTimes {

--- a/test/bigtest/network/scenarios/default.js
+++ b/test/bigtest/network/scenarios/default.js
@@ -3,4 +3,9 @@
 // default scenario is used during `yarn start --mirage`
 // eslint-disable-next-line  no-unused-vars
 export default function defaultScenario(server) {
+  const servicePoints = server.createList('servicePoint', 2);
+
+  server.createList('period', 2, {
+    servicePointId: servicePoints[0].id
+  });
 }

--- a/test/bigtest/tests/scenarios/edit-period-test.js
+++ b/test/bigtest/tests/scenarios/edit-period-test.js
@@ -51,7 +51,7 @@ describe('edit period', () => {
     });
 
     it('should have proper value', () => {
-      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).text).to.equal(
+      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).label.text).to.equal(
         `${formatDateString(period.startDate)} - ${formatDateString(period.endDate)} (${period.name})`
       );
     });
@@ -59,7 +59,7 @@ describe('edit period', () => {
 
   describe('click on created period', () => {
     beforeEach(async () => {
-      await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).click();
+      await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).editButton.click();
     });
 
     it('opening period form should be displayed', () => {
@@ -153,7 +153,7 @@ describe('edit period', () => {
           });
 
           it('should have proper value', () => {
-            expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).text).to.equal(
+            expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).label.text).to.equal(
               `${startDateFuture} - ${endDate} (${period.name})`
             );
           });

--- a/test/bigtest/tests/scenarios/new-period-creation-test.js
+++ b/test/bigtest/tests/scenarios/new-period-creation-test.js
@@ -54,7 +54,7 @@ describe('new period creation', () => {
     });
 
     it('should have proper next period', () => {
-      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).text).to.equal(
+      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).label.text).to.equal(
         `${formatDateString(startDateFuture)} - ${formatDateString(endDate)} (${name})`
       );
     });

--- a/test/bigtest/tests/scenarios/period-deletion-test.js
+++ b/test/bigtest/tests/scenarios/period-deletion-test.js
@@ -34,7 +34,7 @@ describe('period deletion', () => {
     });
 
     it('should have proper value', () => {
-      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).text).to.equal(
+      expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).label.text).to.equal(
         `${formatDateString(period.startDate)} - ${formatDateString(period.endDate)} (${period.name})`
       );
     });
@@ -42,7 +42,7 @@ describe('period deletion', () => {
 
   describe('click on created period', () => {
     beforeEach(async () => {
-      await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).click();
+      await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).editButton.click();
     });
 
     it('opening period form should be displayed', () => {

--- a/test/bigtest/tests/service-point-details-test.js
+++ b/test/bigtest/tests/service-point-details-test.js
@@ -351,14 +351,14 @@ describe('service point details', () => {
       });
 
       it('should have proper value', () => {
-        expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).text).to.equal(
+        expect(calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).label.text).to.equal(
           `${formatDateString(period.startDate)} - ${formatDateString(period.endDate)} (${period.name})`
         );
       });
 
       describe('next period click', () => {
         beforeEach(async () => {
-          await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).click();
+          await calendarSettingsInteractor.servicePointDetails.nextPeriod.list(0).editButton.click();
         });
 
         it('opening period form should be presented', () => {


### PR DESCRIPTION
# Description
Make it easier for the user to access the Modify: Regular library hours validity period page
# Gif
![chrome-capture](https://user-images.githubusercontent.com/42577309/59675346-c0c57500-91cd-11e9-8235-39bfb5626cd0.gif)
