### PR TITLE
MODCAL-45: Increase calendar interface dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       }
     ],
     "okapiInterfaces": {
-      "calendar": "2.0",
+      "calendar": "3.0",
       "service-points": "3.0"
     },
     "permissionSets": [


### PR DESCRIPTION
## Purpose
Increase calendar interface dependency version from **2.0** to **3.0**.
Has to be merged together with https://github.com/folio-org/mod-calendar/pull/85