### PR TITLE
UICAL-75 correctly define settings pset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,7 @@
 
 * Add edit button for new periods (UICAL-71)
 * Add permission to display settings (UICAL-72)
+
+## 2.4.0 (IN PROGRESS)
+
+* Correctly define `settings.calendar.enabled` permission (UICAL-75)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
         "visible": true
       },
       {
+        "permissionName": "settings.calendar.enabled",
+        "displayName": "Settings (Calendar): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      },
+      {
         "permissionName": "ui-calendar.view",
         "displayName": "Settings (Calendar): Can view calendar events",
         "description": "Can view calendar events",
@@ -54,7 +61,6 @@
           "calendar.periods.item.get",
           "module.calendar.enabled",
           "settings.calendar.enabled",
-          "settings.enabled"
         ],
         "visible": true
       },
@@ -63,6 +69,7 @@
         "displayName": "Settings (Calendar): Can create, view, and edit calendar events",
         "description": "Can edit calendar events. User cannot remove any calendar event.",
         "subPermissions": [
+          "settings.calendar.enabled",
           "ui-calendar.view",
           "calendar.periods.item.post",
           "calendar.periods.item.put"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
           "calendar.periods.collection.get",
           "calendar.periods.item.get",
           "module.calendar.enabled",
-          "settings.calendar.enabled",
+          "settings.calendar.enabled"
         ],
         "visible": true
       },


### PR DESCRIPTION
The pset `settings.calendar.enabled` was listed as a subpermission but
never actually defined (it was removed in #194). This caused trouble
when displaying a user with all permissions because the sort function
would explode when it came across the pset with no attributes and it
tried to compare non-existent attributes.

Fixes [UICAL-75](https://issues.folio.org/browse/UICAL-75)