### PR TITLE
UICAL-98: Add Navigation buttons to ExceptionalBigCalendar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,7 @@
 
 * Update translations strings.
 * Update okapi interface version.
+
+## [2.8.0](IN PROGRESS)
+
+* Display the Today, Back and Next buttons on the calendar exceptions screen in the calendar. Refs UICAL-98.

--- a/css/react-big-calendar.css
+++ b/css/react-big-calendar.css
@@ -147,6 +147,39 @@ button.rbc-input::-moz-focus-inner {
 .rbc-btn-group + button {
   margin-left: 10px;
 }
+.rbc-toolbar .rbc-btn-group button[type="button"] {
+  background-color: transparent;
+  border: 1px solid #2b75bb;
+  color: #2b75bb;
+  padding: 0 15px;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 999px;
+  transition: background-color 0.25s, color 0.25s, opacity 0.07s;
+  margin: 0 0 1rem;
+  white-space: nowrap;
+  line-height: 1.5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  outline: 0;
+  opacity: 1;
+  font-weight: 700;
+  font-size: 1rem;
+  min-height: 24px;
+}
+.rbc-toolbar .rbc-btn-group button[type="button"]:hover {
+  background-color:#D3E4F3;
+}
+.rbc-toolbar .rbc-btn-group button[type="button"]:focus {
+  background-color: #2b75bb;
+  border: 1px solid #2b75bb;
+  color: #fff;
+}
+.rbc-toolbar .rbc-btn-group button[type="button"]:nth-child(2) {
+  margin: 0 .5rem 1rem;
+}
 .rbc-event {
   padding: 2px 5px;
   background-color: #3174ad;

--- a/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
+++ b/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
@@ -1,12 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-
 import {
   reduce,
   cloneDeep,
 } from 'lodash';
-
 import {
   Calendar,
   momentLocalizer,
@@ -14,7 +12,7 @@ import {
 
 const localizer = momentLocalizer(moment);
 
-class ExceptionalBigCalendar extends React.Component {
+class ExceptionalBigCalendar extends Component {
   static propTypes = {
     myEvents: PropTypes.arrayOf(PropTypes.object).isRequired,
     getEvent: PropTypes.func.isRequired,
@@ -51,7 +49,7 @@ class ExceptionalBigCalendar extends React.Component {
         localizer={localizer}
         label
         popup
-        toolbar={false}
+        toolbar
         showMultiDayTimes
         events={this.getEvents()}
         views={['month']}


### PR DESCRIPTION
### Description
Display the `Today`, `Back` and `Next` buttons on the calendar exceptions screen in the calendar.

---

### Approach
Set prop `toolbar` to `true` for `Calendar` component.

---

### Issue
https://issues.folio.org/browse/UICAL-98

---

### Screenshot
![image](https://user-images.githubusercontent.com/55694637/71256658-16740900-233a-11ea-9bb5-6ad2f113aa20.png)