### PR TITLE
UICAL-85: Add id attribute to Name input field

### DIFF
--- a/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -182,6 +182,7 @@ class ExceptionalPeriodEditor extends React.Component {
           <Col>
             <div data-test-period-name>
               <Field
+                id="item-period-name"
                 name="item.periodName"
                 component={TextField}
                 label={<FormattedMessage id="ui-calendar.name" />}


### PR DESCRIPTION
# Description
Add `id` attribute to `input` field to improve accessibility
# Issue
https://issues.folio.org/browse/UICAL-85
# Screenshots
### Before
![image](https://user-images.githubusercontent.com/55694637/72341481-0d751e00-36d3-11ea-9390-4de163f7f3d5.png)
### After
![image](https://user-images.githubusercontent.com/55694637/72341500-1a920d00-36d3-11ea-8751-9b3ed2f70dc7.png)