### PR TITLE
UICAL-99: Increase z-index for .rbc-overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,3 +129,4 @@
 * Refactoring of `ExceptionWrapper` component. Refs UICAL-95.
 * Fix bug with ability to create duplicated or overlapped events. Refs UICAL-82.
 * Fix error message shown for duplicated or overlapped events. Fixes UICAL-82.
+* Fix issue the "+ more" link is not working, when patron tries to view all the values for the exception day. Refs UICAl-99.

--- a/css/react-big-calendar.css
+++ b/css/react-big-calendar.css
@@ -343,7 +343,7 @@ button.rbc-input::-moz-focus-inner {
 }
 .rbc-overlay {
   position: absolute;
-  z-index: 5;
+  z-index: 9;
   border: 1px solid #e5e5e5;
   background-color: #fff;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
# Description
The "+ more" link was not working,  when patron tries to view all the values for the exception day.
# Approach
Increase z-index value
# Issue
https://issues.folio.org/browse/UICAL-99
# Screenshot
**After**
![image](https://user-images.githubusercontent.com/55694637/72732984-a0183000-3b9f-11ea-8765-b714fe399177.png)
