### PR TITLE
bump to version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,64 @@
 # Change history for ui-calendar
 
-## [1.0.0]
+## 3.0.0 (IN PROGRESS)
 
-* Create basic calendar application using react-big-calendar (UICAL-1)
-* Create settings page for the module (UICAL-2)
-* Update module with react-big-calendar changes (UICAL-5)
-* Fix save error when adding multiple times within a day (UICAL-6)
-* Filter events by date (UICAL-11)
-* Show event details on click (UICAL-12)
-* Lock react-bootstrap to v0.32.1 to avoid buggy babel-runtime 7.0.0-beta.42 dep. Refs FOLIO-1425.
+* Fix bug with the error message is shown when the start and end dates were already entered. Refs UICAL-95.
+* Refactoring of `ExceptionWrapper` component. Refs UICAL-95.
+* Fix bug with ability to create duplicated or overlapped events. Refs UICAL-82.
+* Fix error message shown for duplicated or overlapped events. Fixes UICAL-82.
+* Fix issue the "+ more" link is not working, when patron tries to view all the values for the exception day. Refs UICAl-99.
+* Rearrange CHANGELOG to be consistent with other core apps
+* Migrate to `stripes` `v3.0.0` and remove `react-intl` from dependencies (it was already a peer).
 
-## [1.0.1] (2018.08.02)
-* Rethink calendar ui
-* https://drive.google.com/open?id=10LT0QsVXKYRD1LRRaVAdlYk02-XUyZjX
+## [2.7.2](https://github.com/folio-org/ui-calendar/tree/v2.7.2) (2019-12-23)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.7.1...v2.7.2)
 
-## [2.0.0] (2018.09.19)
+* Display the Today, Back and Next buttons on the calendar exceptions screen in the calendar. Refs UICAL-98.
 
-* Relocate language files - UICAL-19
-* Fix ui-calendar build error - UICAL-28
-* List available service points - UICAL-23
-* Implement service point panel - UICAL-24
-* Implement new Regular Library Hours Validity Period panel - UICAL-26
-* Implement delete and modify Regular Library Hours Validity Period - UICAL-30
-* Implement delete opening hour - UICAL-31
-* Add validations to opening periods - UICAL-32
-* Confirm dialog before delete opening period	- UICAL-38
-* Confirm dialog before closing editing opening period - UICAL-39
+## [2.7.1](https://github.com/folio-org/ui-calendar/tree/v2.7.1) (2019-12-12)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.7.0...v2.7.1)
 
-## [2.0.1] (2018.09.19)
+* Update translations strings.
+* Update okapi interface version.
 
-* Fix release version
+## [2.7.0](https://github.com/folio-org/ui-calendar/tree/v2.7.0) (2019-12-03)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.6.0...v2.7.0)
 
-## [2.0.2] (2018.09.19)
+* Update translations strings
+* Add handling of exceptional periods errors - UICAL-81
+* Move Save/Cancel buttons to the footer, add a Cancel button to this fixed footer, on New record remove the Delete button - UICAL-92
 
-* Increase node version
+## [2.6.0](https://github.com/folio-org/ui-calendar/tree/v2.6.0) (2019-10-25)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.5.0...v2.6.0)
 
-## [2.0.3] (2018.09.19)
+* Update translations strings
+* Remove non-functional buttons UICAL-79
+* Update react-big-calendar version - UICAL-86
+* Increase amount of visible service points - UICAL-88
 
-* Eliminate linter errors
+## [2.5.0](https://github.com/folio-org/ui-calendar/tree/v2.5.0) (2019-09-11)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.4.0...v2.5.0)
 
-## [2.0.4] (2018.09.20)
+* Update translations strings
 
-* Update reac-big-calendar dependency - UICAL-42
+## [2.4.0](https://github.com/folio-org/ui-calendar/tree/v2.4.0) (2019-08-01)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.3.0...v2.4.0)
 
-## [2.0.6] (2018.12.07)
+* Correctly define `settings.calendar.enabled` permission (UICAL-75)
+* Update translations strings
 
-* Replace stripes intl with react-intl - UICAL-50
-* Update ui-calendar translations - UICAL-51
+## [2.3.0](https://github.com/folio-org/ui-calendar/tree/v2.3.0) (2019-07-24)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.2.0...v2.3.0)
 
-## [2.1.0](https://github.com/folio-org/ui-calendar/tree/v2.1.0) (2019-03-14)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.0.6...v2.1.0)
+* Add edit button for new periods (UICAL-71)
+* Add permission to display settings (UICAL-72)
 
-* Update translation strings
-* Fix applying locale date format for whole module
-* Change BE interface version
-* Apply UTC time zone for date/time controls (UICAL-55)
+## [2.2.0](https://github.com/folio-org/ui-calendar/tree/v2.1.3) (2019-06-12)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.1.3...v2.2.0)
+
+* Prune deps to remove transitive dep on js-yaml v3.7.0 via css-loader > cssnano > postcss-svgo > svgo. Refs FOLIO-2083.
+* Add timezone support for react-big-calendar
+* Cover existing functionality with tests
 
 ## [2.1.1](https://github.com/folio-org/ui-calendar/tree/v2.1.1) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.1.0...v2.1.1)
@@ -73,60 +77,58 @@
 * Fix sending of incorrect model to BE (UICAL-60)
 * Add BigTest setup
 
-## [2.2.0](https://github.com/folio-org/ui-calendar/tree/v2.1.3) (2019-06-12)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.1.3...v2.2.0)
+## [2.1.0](https://github.com/folio-org/ui-calendar/tree/v2.1.0) (2019-03-14)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.0.6...v2.1.0)
 
-* Prune deps to remove transitive dep on js-yaml v3.7.0 via css-loader > cssnano > postcss-svgo > svgo. Refs FOLIO-2083.
-* Add timezone support for react-big-calendar
-* Cover existing functionality with tests
+* Update translation strings
+* Fix applying locale date format for whole module
+* Change BE interface version
+* Apply UTC time zone for date/time controls (UICAL-55)
 
-## [2.3.0](https://github.com/folio-org/ui-calendar/tree/v2.3.0) (2019-07-24)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.2.0...v2.3.0)
+## [2.0.6] (2018.12.07)
 
-* Add edit button for new periods (UICAL-71)
-* Add permission to display settings (UICAL-72)
+* Replace stripes intl with react-intl - UICAL-50
+* Update ui-calendar translations - UICAL-51
 
-## [2.4.0](https://github.com/folio-org/ui-calendar/tree/v2.4.0) (2019-08-01)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.3.0...v2.4.0)
+## [2.0.4] (2018.09.20)
 
-* Correctly define `settings.calendar.enabled` permission (UICAL-75)
-* Update translations strings
+* Update reac-big-calendar dependency - UICAL-42
 
-## [2.5.0](https://github.com/folio-org/ui-calendar/tree/v2.5.0) (2019-09-11)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.4.0...v2.5.0)
+## [2.0.3] (2018.09.19)
 
-* Update translations strings
+* Eliminate linter errors
 
-## [2.6.0](https://github.com/folio-org/ui-calendar/tree/v2.6.0) (2019-10-25)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.5.0...v2.6.0)
+## [2.0.2] (2018.09.19)
 
-* Update translations strings
-* Remove non-functional buttons UICAL-79
-* Update react-big-calendar version - UICAL-86
-* Increase amount of visible service points - UICAL-88
+* Increase node version
 
-## [2.7.0](https://github.com/folio-org/ui-calendar/tree/v2.7.0) (2019-12-03)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.6.0...v2.7.0)
+## [2.0.1] (2018.09.19)
 
-* Update translations strings
-* Add handling of exceptional periods errors - UICAL-81
-* Move Save/Cancel buttons to the footer, add a Cancel button to this fixed footer, on New record remove the Delete button - UICAL-92
+* Fix release version
 
-## [2.7.1](https://github.com/folio-org/ui-calendar/tree/v2.7.1) (2019-12-12)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.7.0...v2.7.1)
+## [2.0.0] (2018.09.19)
 
-* Update translations strings.
-* Update okapi interface version.
+* Relocate language files - UICAL-19
+* Fix ui-calendar build error - UICAL-28
+* List available service points - UICAL-23
+* Implement service point panel - UICAL-24
+* Implement new Regular Library Hours Validity Period panel - UICAL-26
+* Implement delete and modify Regular Library Hours Validity Period - UICAL-30
+* Implement delete opening hour - UICAL-31
+* Add validations to opening periods - UICAL-32
+* Confirm dialog before delete opening period	- UICAL-38
+* Confirm dialog before closing editing opening period - UICAL-39
 
-## [2.7.2](https://github.com/folio-org/ui-calendar/tree/v2.7.2) (2019-12-23)
-[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.7.1...v2.7.2)
+## [1.0.1] (2018.08.02)
+* Rethink calendar ui
+* https://drive.google.com/open?id=10LT0QsVXKYRD1LRRaVAdlYk02-XUyZjX
 
-* Display the Today, Back and Next buttons on the calendar exceptions screen in the calendar. Refs UICAL-98.
+## [1.0.0]
 
-## [2.8.0](IN PROGRESS)
-
-* Fix bug with the error message is shown when the start and end dates were already entered. Refs UICAL-95.
-* Refactoring of `ExceptionWrapper` component. Refs UICAL-95.
-* Fix bug with ability to create duplicated or overlapped events. Refs UICAL-82.
-* Fix error message shown for duplicated or overlapped events. Fixes UICAL-82.
-* Fix issue the "+ more" link is not working, when patron tries to view all the values for the exception day. Refs UICAl-99.
+* Create basic calendar application using react-big-calendar (UICAL-1)
+* Create settings page for the module (UICAL-2)
+* Update module with react-big-calendar changes (UICAL-5)
+* Fix save error when adding multiple times within a day (UICAL-6)
+* Filter events by date (UICAL-11)
+* Show event details on click (UICAL-12)
+* Lock react-bootstrap to v0.32.1 to avoid buggy babel-runtime 7.0.0-beta.42 dep. Refs FOLIO-1425.

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-redux": "^5.0.7",
+    "react-router-dom": "^4.0.0",
     "redux": "^4.0.0",
     "sinon": "^7.3.2",
     "stylelint": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "2.7.2",
+  "version": "3.0.0",
   "description": "Opening hours",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {
@@ -90,9 +90,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.4.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.8.0",
-    "@folio/stripes-core": "^3.4.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -117,12 +117,11 @@
     "react-big-calendar": "^0.22.1",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
-    "react-intl": "^2.7.0",
     "redux-form": "^7.0.3",
     "style-loader": "^0.21.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.4.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*",
     "react-bootstrap": "0.32.1",
     "react-dom": "^16.3.0",


### PR DESCRIPTION
Why a new major version?

* bump the @folio/stripes peer to v3.0.0
* move react-intl to peerDependencies