### PR TITLE
UICAL-105: Fix failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## 3.0.1 (IN PROGRESS)
+
+* Fix failing test. Refs UICAL-105.
+
 ## 3.0.0 ((https://github.com/folio-org/ui-calendar/tree/v3.0.0)
 (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v2.7.2...v3.0.0)

--- a/test/bigtest/tests/calendar-settings-test.js
+++ b/test/bigtest/tests/calendar-settings-test.js
@@ -40,7 +40,7 @@ describe('Calendar settings', () => {
     });
 
     it('should have proper amount of links', () => {
-      expect(calendarSettingsInteractor.allSettings.items().length).to.equal(1);
+      expect(calendarSettingsInteractor.allSettings.items().length).to.equal(2);
     });
 
     describe('calendar link', () => {


### PR DESCRIPTION
# Decsription
Bigtests consistently failing with "Calendar settings should have proper amount of links".
# Approach
Because `Software versions` is located in one `section` with `Settings` links, it is included in amount of links.  Amount of links is 2 instead of 1.
# Issue
https://issues.folio.org/browse/UICAL-105