### PR TITLE
STRIPES-672 remove refs to deprecated proptypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-calendar
 
-## 3.0.1 (IN PROGRESS)
+## 3.1.0 (IN PROGRESS)
 
 * Fix failing test. Refs UICAL-105.
+* Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 
 ## 3.0.0 ((https://github.com/folio-org/ui-calendar/tree/v3.0.0)
 (2020-03-12)

--- a/settings/OpeningPeriodForm/InputFields.js
+++ b/settings/OpeningPeriodForm/InputFields.js
@@ -9,7 +9,6 @@ import {
 import {
   FormattedMessage,
   injectIntl,
-  intlShape,
 } from 'react-intl';
 import {
   Datepicker,
@@ -20,7 +19,7 @@ import {
 
 class InputFields extends React.Component {
   static propTypes = {
-    intl: intlShape.isRequired,
+    intl: PropTypes.object.isRequired,
     onDateChange: PropTypes.func.isRequired,
     onNameChange: PropTypes.func.isRequired,
     nameValue: PropTypes.string.isRequired,

--- a/settings/ServicePointDetails.js
+++ b/settings/ServicePointDetails.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import {
   Button,
   Col,
@@ -487,7 +487,7 @@ class ServicePointDetails extends React.Component {
 
 ServicePointDetails.propTypes = {
   initialValues: PropTypes.object,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object,
   resources: PropTypes.shape({
     periods: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
`intlShape` was removed in `react-intl` >= `v3`.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)