### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-calendar
 
-## 3.0.1 (IN PROGRESS)
+## 3.1.0 (IN PROGRESS)
 
 * Fix failing test. Refs UICAL-105.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## 3.0.0 ((https://github.com/folio-org/ui-calendar/tree/v3.0.0)
 (2020-03-12)

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@folio/react-intl-safe-html": "^1.0.2",
     "dateformat": "^2.0.0",
     "lodash": "^4.17.5",
-    "moment": "^2.22.2",
+    "moment": "~2.24.0",
     "prop-types": "^15.6.1",
     "randomcolor": "^0.5.3",
     "react-big-calendar": "^0.22.1",


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)