### PR TITLE
STRIPES-672 Update stripes, react-intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for ui-calendar
 
-## 3.1.0 (IN PROGRESS)
+## 4.0.0 (IN PROGRESS)
 
 * Fix failing test. Refs UICAL-105.
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
+* Increment `stripes` to `v4.0`, `react-intl` to `v4.5`. Refs STRIPES-672.
 
 ## 3.0.0 ((https://github.com/folio-org/ui-calendar/tree/v3.0.0)
 (2020-03-12)

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "stylelint-junit-formatter": "^0.2.1"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.2",
+    "@folio/react-intl-safe-html": "^2.0.0",
     "dateformat": "^2.0.0",
     "lodash": "^4.17.5",
     "moment": "~2.24.0",

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^4.0.0",
     "@folio/stripes-cli": "^1.8.0",
-    "@folio/stripes-core": "^4.0.0",
+    "@folio/stripes-core": "^5.0.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -122,11 +122,11 @@
     "style-loader": "^0.21.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^4.0.0",
     "react": "*",
     "react-bootstrap": "0.32.1",
     "react-dom": "^16.3.0",
-    "react-intl": "^2.4.0",
+    "react-intl": "^4.5.3",
     "react-router-dom": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-redux": "^5.0.7",
+    "react-intl": "^4.5.3",
     "react-router-dom": "^4.0.0",
     "redux": "^4.0.0",
     "sinon": "^7.3.2",


### PR DESCRIPTION
Increment `stripes` to `v4.0`, `react-intl` to `v4.5`.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)