### PR TITLE
UICAL-124: Fix datepicker's overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.0 IN PROGRESS
 
 * Remove unused `react-bootstrap` dependency. Refs UICAL-123.
+* Calendar `Datepicker` cut off in add exception screen. Refs UICAL-124.
 
 ## [5.0.0](https://github.com/folio-org/ui-calendar/tree/v5.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v4.0.0...v5.0.0)

--- a/src/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/src/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -169,6 +169,7 @@ class ExceptionalPeriodEditor extends React.Component {
                 timeZone="UTC"
                 dateFormat={formatMessage({ id: 'ui-calendar.dateFormat' })}
                 backendDateStandard="YYYY-MM-DD"
+                usePortal
               />
             </div>
           </Col>
@@ -185,6 +186,7 @@ class ExceptionalPeriodEditor extends React.Component {
                 timeZone="UTC"
                 dateFormat={formatMessage({ id: 'ui-calendar.dateFormat' })}
                 backendDateStandard="YYYY-MM-DD"
+                usePortal
               />
             </div>
           </Col>


### PR DESCRIPTION
# Description
Calendar `Datepicker` cut off in add exception screen
# Issue
https://issues.folio.org/browse/UICAL-124
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/98377808-f16daf00-204d-11eb-8cb2-69d09c23d52e.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/98377965-195d1280-204e-11eb-9f57-8b8d31460cf0.png)
