### PR TITLE
UICAL-144: Fix failed test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update the .gitignore file. Refs UICAL-135.
 * Add pull request template. Refs UICAL-136.
+* Fix failed test. Refs UICAL-144.
 
 ## [6.0.0](https://github.com/folio-org/ui-calendar/tree/v6.0.0) (2021-03-09)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v5.0.1...v6.0.0)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,6 @@
+/** @param {import('karma').Config} config */
+module.exports = config => config.set({
+  client: {
+    captureConsole: false,
+  },
+});

--- a/test/bigtest/tests/scenarios/new-period-events-test.js
+++ b/test/bigtest/tests/scenarios/new-period-events-test.js
@@ -62,11 +62,11 @@ describe('calendar events', () => {
 
     describe('dnd', () => {
       beforeEach(async function () {
-        const events = await calendarSettingsInteractor.openingPeriodForm.bigCalendar.events();
         const timeslots = await calendarSettingsInteractor.openingPeriodForm.bigCalendar.timeSlots();
 
+        await calendarSettingsInteractor.openingPeriodForm.bigCalendar.eventDeleteButtons(0).click();
         await calendarSettingsInteractor.openingPeriodForm.bigCalendar.simulateClick(
-          events[0],
+          timeslots[54],
           timeslots[56],
         );
       });


### PR DESCRIPTION
## Purpose
Fix failed test

## Approach
`await calendarSettingsInteractor.openingPeriodForm.bigCalendar.eventDeleteButtons(0).click();` - remove event that was created in parent beforeEach
`const events = await calendarSettingsInteractor.openingPeriodForm.bigCalendar.events(); `- remove line we don't need event 
`simulateClick(startElement, endElement)` - simulateClick should get startElement and  endElement change from events[0] to timeslots[54],
Add karma.conf.js

## Stories
https://issues.folio.org/browse/UICAL-144

## Screenshot
### Before 
![image](https://user-images.githubusercontent.com/24813219/121932788-f5814e00-cd4d-11eb-8b44-974edb52d371.png)

### After
Tests can be started without error
![image](https://user-images.githubusercontent.com/24813219/121932671-ce2a8100-cd4d-11eb-968b-71b9048130cf.png)
