### PR TITLE
UICAL-139: Fix import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## [7.0.0] (IN PROGRESS)
+
+* Fix import paths. Refs UICAL-139.
+
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)
 

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -16,7 +16,7 @@ import {
   ConfirmationModal,
   Modal
 } from '@folio/stripes/components';
-import { IfPermission } from '@folio/stripes-core';
+import { IfPermission } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html' ;// eslint-disable-line
 
 import ServicePointSelector from './ServicePointSelector';

--- a/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
+++ b/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { isEmpty } from 'lodash';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { IfPermission } from '@folio/stripes-core';
+import { IfPermission } from '@folio/stripes/core';
 import {
   Button,
   ConfirmationModal,

--- a/src/settings/ServicePointDetails.js
+++ b/src/settings/ServicePointDetails.js
@@ -13,7 +13,7 @@ import {
   IconButton,
 } from '@folio/stripes/components';
 import moment from 'moment';
-import { IfPermission } from '@folio/stripes-core';
+import { IfPermission } from '@folio/stripes/core';
 import OpeningPeriodFormWrapper from './OpeningPeriodForm/OpeningPeriodFormWrapper';
 import ErrorBoundary from '../ErrorBoundary';
 import ExceptionWrapper from './OpenExceptionalForm/ExceptionWrapper';


### PR DESCRIPTION
## Purpose
Fix import paths

## Approach
Component imports should happen through the @folio/stripes/${repo} namespace rather than directly via the repo's private path. e.g. prefer

`import LocationSelection from '@folio/stripes/smart-components/LocationSelection';`
instead of

`import LocationSelection from '@folio/stripes-smart-components/lib/LocationSelection';`
The following files contain incorrect imports:

## Stories
https://issues.folio.org/browse/UICAL-139