### PR TITLE
UICAL-138: Compile Translation Files into AST Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.0.0] (IN PROGRESS)
 
 * Fix import paths. Refs UICAL-139.
+* Compile Translation Files into AST Format. Refs UICAL-138.
 
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@ buildNPM {
   publishModDescriptor = 'yes'
   runLint = 'yes'
   runSonarqube = true
-  runTest = 'yes'
-  runTestOptions = '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
+  runScripts = [
+    ['formatjs-compile': ''],
+    ['test':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'],
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
   "scripts": {
     "start": "stripes serve",
     "lint": "eslint .",
-    "test": "stripes test karma"
+    "test": "stripes test karma",
+    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-calendar ./translations/ui-calendar/compiled"
   },
   "devDependencies": {
     "@bigtest/convergence": "^1.0.0",
@@ -94,6 +95,7 @@
     "@folio/stripes": "^6.0.0",
     "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-core": "^7.0.0",
+    "@formatjs/cli": "^4.2.21",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
## Purpose
Compile Translation Files into AST Format

## Stories
https://issues.folio.org/browse/UICAL-138

## Screenshots'
Command execution result (yarn formatjs-compile)
![UICAL-138](https://user-images.githubusercontent.com/24813219/123422487-f70d0a80-d5c6-11eb-8c0b-6900147627fc.JPG)
![UICAL-138_2](https://user-images.githubusercontent.com/24813219/123422590-1ad05080-d5c7-11eb-899d-f04ed74505a8.JPG)