### PR TITLE
UICAL-150: Fix failed test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix import paths. Refs UICAL-139.
 * Compile Translation Files into AST Format. Refs UICAL-138.
+* Fix failed test. Refs UICAL-150.
 
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)

--- a/test/bigtest/interactors/ExeptionalForm.js
+++ b/test/bigtest/interactors/ExeptionalForm.js
@@ -3,6 +3,7 @@ import {
   scoped,
   Interactor,
   collection,
+  isPresent,
 } from '@bigtest/interactor';
 
 // eslint-disable-next-line
@@ -20,6 +21,12 @@ import ConfirmationModal from './ConfirmationModal';
   defaultScope = '[data-test-service-point-selector]';
 
   items = collection('[data-test-service-point]', CheckboxInteractor);
+
+  isLoaded = isPresent('[data-test-service-point-selector]');
+
+  whenLoaded() {
+    return this.when(() => this.isLoaded);
+  }
 }
 
 @interactor class ServicePoints {

--- a/test/bigtest/tests/scenarios/new-exceptional-period-test.js
+++ b/test/bigtest/tests/scenarios/new-exceptional-period-test.js
@@ -57,6 +57,7 @@ describe('open exceptional form', () => {
 
       describe('service point click', () => {
         beforeEach(async function () {
+          await calendarSettingsInteractor.exceptionalForm.servicePointSelector.whenLoaded();
           await calendarSettingsInteractor.exceptionalForm.servicePointSelector.items(testServicePointId).clickAndBlur();
         });
 
@@ -86,6 +87,7 @@ describe('open exceptional form', () => {
 
       describe('service point click', () => {
         beforeEach(async function () {
+          await calendarSettingsInteractor.exceptionalForm.servicePointSelector.whenLoaded();
           await calendarSettingsInteractor.exceptionalForm.servicePointSelector.items(testServicePointId).clickAndBlur();
         });
 
@@ -115,6 +117,7 @@ describe('open exceptional form', () => {
 
       describe('service point click', () => {
         beforeEach(async function () {
+          await calendarSettingsInteractor.exceptionalForm.servicePointSelector.whenLoaded();
           await calendarSettingsInteractor.exceptionalForm.servicePointSelector.items(testServicePointId).clickAndBlur();
         });
 


### PR DESCRIPTION
## Purpose
Fix failed test

## Approach
We should wait until `servicePointSelector` will present on a page

## Stories
https://issues.folio.org/browse/UICAL-150

## Screenshot
### Before 
![image](https://user-images.githubusercontent.com/24813219/128213925-ff32ca6c-2371-46f6-8509-c2845148d780.png)

![image](https://user-images.githubusercontent.com/24813219/128211996-eeccea8c-e8f5-4d82-ab45-7e7e80a32619.png)
### After
![image](https://user-images.githubusercontent.com/24813219/128212115-96d3bbc6-4167-4782-89d8-2c43ad7e6fb6.png)
