### PR TITLE
UICAL-152: Fix calendar exceptions displaying on wrong day of week (offset by a day)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fix import paths. Refs UICAL-139.
 * Compile Translation Files into AST Format. Refs UICAL-138.
 * Fix failed test. Refs UICAL-150.
+* Fix calendar exceptions displaying on wrong day of week (offset by a day). Refs UICAL-152.
+* Fix that last day of work library is carried over to the previous day. Refs UICAL-157.
 
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -30,6 +30,10 @@ import {
   ALL_DAY,
 } from '../constants';
 
+import {
+  OFFSET_HOURS,
+} from '../utils/time';
+
 class ExceptionWrapper extends Component {
   static propTypes = {
     entries: PropTypes.arrayOf(PropTypes.object),
@@ -364,6 +368,7 @@ class ExceptionWrapper extends Component {
       .diff(moment(start), 'days') + 1; i++) {
       const today = moment(start)
         .add(i, 'days')
+        .add(OFFSET_HOURS, 'hours')
         .format('dddd')
         .toUpperCase();
 

--- a/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
+++ b/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
@@ -6,6 +6,10 @@ import {
   momentLocalizer,
 } from 'react-big-calendar';
 
+import {
+  OFFSET_HOURS,
+} from '../utils/time';
+
 const localizer = momentLocalizer(moment);
 
 class ExceptionalBigCalendar extends Component {
@@ -13,6 +17,10 @@ class ExceptionalBigCalendar extends Component {
     myEvents: PropTypes.arrayOf(PropTypes.object).isRequired,
     getEvent: PropTypes.func.isRequired,
   };
+
+  accessor = (date) => {
+    return moment(date).clone().add(OFFSET_HOURS, 'hours').toDate();
+  }
 
   render() {
     const {
@@ -31,6 +39,8 @@ class ExceptionalBigCalendar extends Component {
         views={['month']}
         onSelectEvent={getEvent}
         style={{ height: '90vh' }}
+        startAccessor={(event) => this.accessor(event.start)}
+        endAccessor={(event) => this.accessor(event.end)}
       />
     );
   }

--- a/src/settings/utils/time.js
+++ b/src/settings/utils/time.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const OFFSET_HOURS = (new Date().getTimezoneOffset()) / 60;


### PR DESCRIPTION
## Purpose
Day of work and exceptions displaying on wrong day of week

## Approach
We have some problem in react-big-calendar with timezone (Moves everything over a day) more details in 
https://github.com/jquense/react-big-calendar/issues/118 , 
https://github.com/jquense/react-big-calendar/issues/809 and etc.
How you can see for timezone 0 and bigger work correctly (Screenshot section). Current bug reproducible only for  timezone less than 0. This is problem with "react-big-calendar" all the days shifts over by 1 and this is workaround for resolve problem with "react-big-calendar". For resolve current problem we use accessor and offset hours.

## Stories
https://issues.folio.org/browse/UICAL-152
https://issues.folio.org/browse/UICAL-157

## Screenshot
#### Before changes (example with deferent timezone)
UTC+2
![image](https://user-images.githubusercontent.com/24813219/132003318-4cbabd6b-4620-4748-8f42-3f9ae46c9d7b.png)
UTC -1
![image](https://user-images.githubusercontent.com/24813219/132003470-8b1e0988-6331-4ab9-92a9-ef6f0e951cbb.png)
UTC -12
![image](https://user-images.githubusercontent.com/24813219/132003654-b311a52b-3a43-499f-ab31-68cd27aadd89.png)
shifted days for timezone less than 0
![image](https://user-images.githubusercontent.com/24813219/131664981-3d545dc6-dcaf-4195-a0ab-423b4a0330bd.png)
#### After changes
![image](https://user-images.githubusercontent.com/24813219/131665056-b1e7cc1f-0f86-4365-8c15-cdbcb8847406.png)

