### PR TITLE
UICAL-127: fix the issue when time period is not displayed if the end date is current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix import paths. Refs UICAL-139.
 * Compile Translation Files into AST Format. Refs UICAL-138.
 * Fix failed test. Refs UICAL-150.
+* Fix the issue when time period is not displayed if the end date is current. Refs UICAL-127
 
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)

--- a/src/settings/ServicePointDetails.js
+++ b/src/settings/ServicePointDetails.js
@@ -105,15 +105,20 @@ class ServicePointDetails extends React.Component {
       const openingPeriod = this.state.openingPeriods[index];
       const start = moment.utc(openingPeriod.startDate);
       const end = moment.utc(openingPeriod.endDate);
-      const now = moment.utc();
+      const now = moment.utc().set({
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      });
 
-      if (now > start && now < end) {
+      if (moment(now).isSameOrAfter(start) && moment(now).isSameOrBefore(end)) {
         res = {
           startDate: <FormattedUTCDate value={openingPeriod.startDate} />,
           endDate: <FormattedUTCDate value={openingPeriod.endDate} />,
           name: openingPeriod.name,
           openingDays: openingPeriod.openingDays,
-          id: openingPeriod.id
+          id: openingPeriod.id,
         };
       }
     }
@@ -133,7 +138,7 @@ class ServicePointDetails extends React.Component {
           id: openingPeriod.id,
           startDate: <FormattedUTCDate value={openingPeriod.startDate} />,
           endDate: <FormattedUTCDate value={openingPeriod.endDate} />,
-          name: openingPeriod.name
+          name: openingPeriod.name,
         });
       }
     }
@@ -441,7 +446,7 @@ class ServicePointDetails extends React.Component {
             isOpen={this.state.newPeriodLayer.isOpen}
             contentLabel={this.props.intl.formatMessage({
               id: 'stripes-core.label.editEntry',
-              values: { entry: this.props.entryLabel }
+              values: { entry: this.props.entryLabel },
             })}
             container={document.getElementById('ModuleContainer')}
           >
@@ -458,7 +463,7 @@ class ServicePointDetails extends React.Component {
             isOpen={this.state.modifyPeriodLayer.isOpen}
             contentLabel={this.props.intl.formatMessage({
               id: 'stripes-core.label.editEntry',
-              values: { entry: this.props.entryLabel }
+              values: { entry: this.props.entryLabel },
             })}
             container={document.getElementById('ModuleContainer')}
           >
@@ -475,7 +480,7 @@ class ServicePointDetails extends React.Component {
             isOpen={this.state.openExceptions.isOpen}
             contentLabel={this.props.intl.formatMessage({
               id: 'stripes-core.label.editEntry',
-              values: { entry: this.props.entryLabel }
+              values: { entry: this.props.entryLabel },
             })}
             container={document.getElementById('ModuleContainer')}
           >
@@ -509,7 +514,7 @@ ServicePointDetails.propTypes = {
   resources: PropTypes.shape({
     periods: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
-    })
+    }),
   }),
 };
 


### PR DESCRIPTION
## Purpose
fix the issue when time period is not displayed if the end date is current

## Refs
https://issues.folio.org/browse/UICAL-127

## Approach
There was a case where "now" moment was with current time, and "start" and "end" moments was without it. So when we try check is "now" < "end" is always was false. After changes "now" moment in the same form as "start" and "end" moments.
Also we need to change ">" or "<" for "> =" or "<=" if we want to include cases when end date is current.
In additional we resolved change comparisons methods for more suitable in this case, when we compare not numbers but dates.

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/132020274-31846c34-56f5-4509-a57d-91497b9299f2.png)
![image](https://user-images.githubusercontent.com/88130496/132021662-b30ecad6-36af-402d-aa95-09debbb42e19.png)