### PR TITLE
UICAL-161 Remove style-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
     "redux-form": "^8.3.7",
-    "style-loader": "^0.21.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-big-calendar": "^0.22.1",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
-    "redux-form": "^8.3.7",
+    "redux-form": "^8.3.7"
   },
   "peerDependencies": {
     "@folio/stripes": "^6.0.0",


### PR DESCRIPTION
This dependency doesn't appear to be in use by the module - it's currently interfering with platform builds as it's being hoisted above a newer version of the module (most likely due to being a 0.*.* version (viewed as major 21 over a v 1.0.0) due to semver resolutions...