### PR TITLE
UICAL-161 style-loader should only be a dev-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "sinon": "^7.3.2",
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0",
-    "stylelint-junit-formatter": "^0.2.1"
+    "stylelint-junit-formatter": "^0.2.1",
+    "style-loader": "^0.21.0"
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
@@ -125,8 +126,7 @@
     "react-big-calendar": "^0.22.1",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
-    "redux-form": "^8.3.7",
-    "style-loader": "^0.21.0"
+    "redux-form": "^8.3.7"
   },
   "peerDependencies": {
     "@folio/stripes": "^6.0.0",


### PR DESCRIPTION
@JohnC-80's PR #346 notwithstanding, BigTest is choking in CI. This is
just a different twist on the same problem, keeping the version of
`style-loader` the same, rather than removing (or updating) it, but
moving it to dev-deps where it _would_ belong if it belonged here at
all, which it doesn't, but since tests fail without it ... well, here we
are.

Refs [UICAL-161](https://issues.folio.org/browse/UICAL-161)