### PR TITLE
UICAL-134: fix browser crash related to library hours viewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix the issue when time period is not displayed if the end date is current. Refs UICAL-127
 * Fix failed build on `ui-calendar`. Refs UICAL-162.
 * Increment `stripes` to `v7`, `react` to `v17`. Refs UICAL-154.
+* Fix issue when viewing library hours causes browser crash after viewing other settings. Refs UICAL-134.
 
 ## [6.1.0] (https://github.com/folio-org/ui-calendar/tree/v6.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.0.0...v6.1.0)

--- a/src/settings/LibraryHours.js
+++ b/src/settings/LibraryHours.js
@@ -36,8 +36,8 @@ class LibraryHours extends React.Component {
         },
         PUT: {
           path: 'calendar/periods/%{query}/period/%{periodId}',
-        }
-      }
+        },
+      },
     });
 
     constructor() {
@@ -62,10 +62,9 @@ class LibraryHours extends React.Component {
         renderedCloneSettings = <CloneSettings {...this.props} onToggle={that.onChildToggle()} />;
       }
       const sortedList = sortBy((this.props.resources.entries || {}).records || [], ['name']);
-      if (sortedList !== undefined && sortedList !== null) {
-        for (let i = 0; i < sortedList.length; i++) {
-          sortedList[i].allEntries = sortBy((this.props.resources.entries || {}).records || [], ['name']);
-        }
+
+      for (let i = 0; i < sortedList.length; i++) {
+        sortedList[i].allEntries = sortedList;
       }
 
       return (
@@ -100,7 +99,7 @@ LibraryHours.propTypes = {
     }),
     periods: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
-    })
+    }),
   }).isRequired,
   mutator: PropTypes.shape({
     entries: PropTypes.shape({


### PR DESCRIPTION
## Purpose
Fix browser crash related to library hours viewing

## Approach
Unnecessary condition was deleted. Because `sortedList` never will be equal `undefined` or `null` . Also unnecessary repeated sort was deleted, which was the problem I think.

## Refs
https://issues.folio.org/browse/UICAL-134