### PR TITLE
UICAL-176: Calculate localized start of week offset to display periods correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICAL-173.
+* Fix edit view improperly localizing start of week. Refs UICAL-176
 
 ## [7.0.0] (https://github.com/folio-org/ui-calendar/tree/v7.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.1.2...v7.0.0)

--- a/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
+++ b/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
@@ -53,9 +53,16 @@ class BigCalendarWrapper extends PureComponent {
         }
       }) => {
         const event = {};
+        // localized start of week
         let eventDay = moment().startOf('week').toDate();
+        // 0 to 6 from Sunday - Saturday.  Not localized
+        const localizedStartDay = moment(eventDay).day();
+        // distance from Sunday (where `weekdays` array starts to actual start day)
+        // add seven to keep this positive (stay in week we're displaying)
+        const localizedStartOffset = (0 - localizedStartDay) + 7;
 
-        eventDay = moment(eventDay).add(weekdays.indexOf(weekday), 'day');
+        // add the offset to ensure weekdays array correlates to presented week
+        eventDay = moment(eventDay).add((weekdays.indexOf(weekday) + localizedStartOffset) % 7, 'day');
         event.start = moment(eventDay);
         event.end = moment(eventDay);
         event.allDay = allDay;

--- a/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
+++ b/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
@@ -9,7 +9,7 @@ import {
   momentLocalizer,
 } from 'react-big-calendar';
 
-import { ALL_DAY } from '../constants';
+import { ALL_DAY, NUMBER_OF_DAYS_IN_WEEK } from '../constants';
 import CalendarUtils from '../../CalendarUtils';
 import EventComponent from '../../components/EventComponent';
 
@@ -53,16 +53,12 @@ class BigCalendarWrapper extends PureComponent {
         }
       }) => {
         const event = {};
-        // localized start of week
-        let eventDay = moment().startOf('week').toDate();
-        // 0 to 6 from Sunday - Saturday.  Not localized
-        const localizedStartDay = moment(eventDay).day();
-        // distance from Sunday (where `weekdays` array starts to actual start day)
-        // add seven to keep this positive (stay in week we're displaying)
-        const localizedStartOffset = (0 - localizedStartDay) + 7;
+        const localizedStartOfWeek = moment().startOf('week').toDate();
+        const relativeStartOfWeek = moment(eventDay).day(); // 0 to 6 from Sunday - Saturday.  Not localized
+        const localizedStartOffset = (0 - relativeStartOfWeek) + NUMBER_OF_DAYS_IN_WEEK; // force positive
 
         // add the offset to ensure weekdays array correlates to presented week
-        eventDay = moment(eventDay).add((weekdays.indexOf(weekday) + localizedStartOffset) % 7, 'day');
+        const eventDay = moment(localizedStartOfWeek).add((weekdays.indexOf(weekday) + localizedStartOffset) % NUMBER_OF_DAYS_IN_WEEK, 'day');
         event.start = moment(eventDay);
         event.end = moment(eventDay);
         event.allDay = allDay;

--- a/src/settings/constants.js
+++ b/src/settings/constants.js
@@ -32,4 +32,6 @@ export const permissions = {
   PUT:  'calendar.periods.item.put'
 };
 
+export const NUMBER_OF_DAYS_IN_WEEK = 7;
+
 export const ALL_DAY = <FormattedMessage id="ui-calendar.settings.allDay" />;


### PR DESCRIPTION
[UICAL-176](https://issues.folio.org/projects/UICAL/issues/UICAL-176)

## Purpose
This fixes an issue for localized users where the start of the week is not Monday.  The system will correctly parse and save the events when a new period is created (as it uses `Date.getDay()` which is non-localized), however, when recreating the calendar, moment's `startOf('week')` is localized.  The existing code calculated absolute offsets from Sunday, etc using a hardcoded array, then added them to the localized start of week, resulting in issues when the week did not start on Sunday.

## Approach
An additional calculation was added to determine the offset between Sunday and the localized start of the week.  This was then used to calculate how the periods should be displayed relative to this localized start of the week, correctly displaying them on the calendar.

## Refs
[UICAL-176](https://issues.folio.org/projects/UICAL/issues/UICAL-176)

## Screenshots
Screenshots of the issue are in the Jira ticket.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
