### PR TITLE
UICAL-175: Long exception periods display wrong days and subsequent e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICAL-173.
 * Fix issue when after the transition from summer to winter time, the graphical interface displays Exception Period one day less. Refs UICAL-181.
+* Fix long exception periods display wrong days and subsequent exception periods display on the wrong days. Refs UICAL-175.
 
 ## [7.0.0] (https://github.com/folio-org/ui-calendar/tree/v7.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.1.2...v7.0.0)

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -30,9 +30,7 @@ import {
   ALL_DAY,
 } from '../constants';
 
-import {
-  OFFSET_HOURS,
-} from '../utils/time';
+import { setTimezoneOffset } from '../utils/time';
 
 class ExceptionWrapper extends Component {
   static propTypes = {
@@ -366,9 +364,8 @@ class ExceptionWrapper extends Component {
 
     for (let i = 0; i < moment.utc(end)
       .diff(moment.utc(start), 'days') + 1; i++) {
-      const today = moment(start)
+      const today = setTimezoneOffset(start)
         .add(i, 'days')
-        .add(OFFSET_HOURS, 'hours')
         .format('dddd')
         .toUpperCase();
 
@@ -460,10 +457,11 @@ class ExceptionWrapper extends Component {
             {eventContent}
           </div>;
 
+        const eventStart = setTimezoneOffset(start).add(i, 'days');
         const tempObj = {
           id,
-          end: moment(start).add(i, 'days'),
-          start: moment(start).add(i, 'days'),
+          end: eventStart.clone(),
+          start: eventStart,
           title: eventTitle,
           exceptional,
         };

--- a/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
+++ b/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
@@ -6,10 +6,6 @@ import {
   momentLocalizer,
 } from 'react-big-calendar';
 
-import {
-  OFFSET_HOURS,
-} from '../utils/time';
-
 const localizer = momentLocalizer(moment);
 
 class ExceptionalBigCalendar extends Component {
@@ -17,10 +13,6 @@ class ExceptionalBigCalendar extends Component {
     myEvents: PropTypes.arrayOf(PropTypes.object).isRequired,
     getEvent: PropTypes.func.isRequired,
   };
-
-  accessor = (date) => {
-    return moment(date).clone().add(OFFSET_HOURS, 'hours').toDate();
-  }
 
   render() {
     const {
@@ -39,8 +31,6 @@ class ExceptionalBigCalendar extends Component {
         views={['month']}
         onSelectEvent={getEvent}
         style={{ height: '90vh' }}
-        startAccessor={(event) => this.accessor(event.start)}
-        endAccessor={(event) => this.accessor(event.end)}
       />
     );
   }

--- a/src/settings/utils/time.js
+++ b/src/settings/utils/time.js
@@ -1,2 +1,9 @@
+import moment from 'moment';
+
 // eslint-disable-next-line import/prefer-default-export
-export const OFFSET_HOURS = (new Date().getTimezoneOffset()) / 60;
+export const setTimezoneOffset = (date) => {
+  const momentDate = moment(date);
+  const utcOffset = -(momentDate.utcOffset() / 60);
+
+  return momentDate.add(utcOffset, 'hours');
+};


### PR DESCRIPTION
## Purpose
Fix long exception periods display wrong days and subsequent exception periods display on the wrong days.

## Approach
Calendar can get dates which can have different timezone offset because of transition to winter time. So we have to get utc offset from each date instead of using constant `OFFSET_HOURS` which returns utc offset for today.

Also for performance improvement I've moved this logic from `startAccessor` and `endAccessor` to the place where events are created. It is necessary because `startAccessor` and `endAccessor` are called for cells which have events and which have no events.

## Refs
https://issues.folio.org/browse/UICAL-175

