### PR TITLE
UICAL-181: After the transition from summer to winter time, the graph…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICAL-173.
+* Fix issue when after the transition from summer to winter time, the graphical interface displays Exception Period one day less. Refs UICAL-181.
 
 ## [7.0.0] (https://github.com/folio-org/ui-calendar/tree/v7.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.1.2...v7.0.0)

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -364,8 +364,8 @@ class ExceptionWrapper extends Component {
     } = event;
     let g = 0;
 
-    for (let i = 0; i < moment(end)
-      .diff(moment(start), 'days') + 1; i++) {
+    for (let i = 0; i < moment.utc(end)
+      .diff(moment.utc(start), 'days') + 1; i++) {
       const today = moment(start)
         .add(i, 'days')
         .add(OFFSET_HOURS, 'hours')


### PR DESCRIPTION
## Purpose
After the transition from summer to winter time, the graphical interface displays Exception Period one day less.

## Approach
[Here](https://github.com/moment/moment/blob/develop/src/lib/moment/diff.js#L42) is how moment `diff` method works if you want to get `days` diff. It works incorrectly for two dates(the first date must be before and the second date must be after Daylight saving time). It is `moment.js` library issue and it is related to `zoneDelta`.

If you use `moment.utc` method instead of 'moment' to create date then moment `diff` method works correctly.

## Refs
https://issues.folio.org/browse/UICAL-181

