### PR TITLE
UICAL-182: remove dependencies by vulnerability reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICAL-173.
 * Fix issue when after the transition from summer to winter time, the graphical interface displays Exception Period one day less. Refs UICAL-181.
+* Remove `react-dnd` and `react-dnd-html5-backend` by security vulnerability reason. Refs UICAL-182.
 
 ## [7.0.0] (https://github.com/folio-org/ui-calendar/tree/v7.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.1.2...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -125,8 +125,6 @@
     "prop-types": "^15.6.1",
     "randomcolor": "^0.5.3",
     "react-big-calendar": "^0.22.1",
-    "react-dnd": "^5.0.0",
-    "react-dnd-html5-backend": "^5.0.1",
     "redux-form": "^8.3.7"
   },
   "peerDependencies": {

--- a/src/settings/OpeningPeriodForm/BigCalendarWrapper.css
+++ b/src/settings/OpeningPeriodForm/BigCalendarWrapper.css
@@ -1,0 +1,4 @@
+.periodBigCalendar {
+  height: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
+++ b/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
@@ -1,9 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import HTML5Backend from 'react-dnd-html5-backend';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
-import { DragDropContext } from 'react-dnd';
 import {
   Calendar,
   momentLocalizer,
@@ -12,6 +10,8 @@ import {
 import { ALL_DAY } from '../constants';
 import CalendarUtils from '../../CalendarUtils';
 import EventComponent from '../../components/EventComponent';
+
+import style from './BigCalendarWrapper.css';
 
 const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(Calendar);
@@ -49,8 +49,8 @@ class BigCalendarWrapper extends PureComponent {
           openingHour,
         },
         weekdays: {
-          day: weekday
-        }
+          day: weekday,
+        },
       }) => {
         const event = {};
         let eventDay = moment().startOf('week').toDate();
@@ -91,7 +91,7 @@ class BigCalendarWrapper extends PureComponent {
       eventsChange(events);
       this.setState({
         events,
-        eventIdCounter: eventId
+        eventIdCounter: eventId,
       });
     }
   }
@@ -183,7 +183,7 @@ class BigCalendarWrapper extends PureComponent {
     onCalendarChange = (events) => {
       this.setState({
         events,
-        eventIdCounter: events.length
+        eventIdCounter: events.length,
       });
 
       this.props.onCalendarChange(events);
@@ -204,11 +204,7 @@ class BigCalendarWrapper extends PureComponent {
     render() {
       return (
         <div
-          className="period-big-calendar"
-          style={{
-            height: '100%',
-            marginBottom: '1rem',
-          }}
+          className={style.periodBigCalendar}
           data-test-big-calendar-wrapper
         >
           <DnDCalendar
@@ -224,7 +220,7 @@ class BigCalendarWrapper extends PureComponent {
             onSelectSlot={this.onSlotSelect}
             views={['week']}
             components={{
-              event: this.renderEventComponent
+              event: this.renderEventComponent,
             }}
             labelTranslate={CalendarUtils.translate}
           />
@@ -233,4 +229,4 @@ class BigCalendarWrapper extends PureComponent {
     }
 }
 
-export default DragDropContext(HTML5Backend)(BigCalendarWrapper);
+export default BigCalendarWrapper;


### PR DESCRIPTION
## Purpose
Remove node-fetch file size limit security vulnerability (CVE-2020-15168)

## Approach
Now calendar module can work correctly without `react-dnd` and `react-dnd-html5-backend`. All drag'n'drop functionalyti working with using native react-big-calendar utils. We tested it - everything is fine.

## Refs
https://issues.folio.org/browse/UICAL-182