### PR TITLE
UICAL-185: use constant instead of hardcoded value for query limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve grammar in pull request template. Refs UICAL-184.
 * Remove `react-dnd` and `react-dnd-html5-backend` by security vulnerability reason. Refs UICAL-182.
 * Fix spacing on exception modal service point picker. Refs UICAL-145.
+* Use constant instead of hardcoded value for query limit. Refs UICAL-185.
 
 ## [7.0.1] (https://github.com/folio-org/ui-calendar/tree/v7.0.1) (2021-11-11)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.0.0...v7.0.1)

--- a/src/settings/LibraryHours.js
+++ b/src/settings/LibraryHours.js
@@ -6,6 +6,8 @@ import ServicePointDetails from './ServicePointDetails';
 import ErrorBoundary from '../ErrorBoundary';
 import CloneSettings from './CloneSettings';
 
+import { MAX_RECORDS } from './constants';
+
 class LibraryHours extends React.Component {
     static manifest = Object.freeze({
       entries: {
@@ -15,7 +17,7 @@ class LibraryHours extends React.Component {
         path: 'service-points',
         params: {
           query: 'cql.allRecords=1',
-          limit: '1000',
+          limit: MAX_RECORDS,
         },
       },
       query: {},

--- a/src/settings/constants.js
+++ b/src/settings/constants.js
@@ -23,13 +23,15 @@ export const colors = [
   '#a9a9a9',
   '#ffffff',
   '#000000',
-  '#e6194B'
+  '#e6194B',
 ];
 
 export const permissions = {
   DELETE: 'calendar.periods.item.delete',
   POST: 'calendar.periods.item.post',
-  PUT:  'calendar.periods.item.put'
+  PUT:  'calendar.periods.item.put',
 };
 
 export const ALL_DAY = <FormattedMessage id="ui-calendar.settings.allDay" />;
+
+export const MAX_RECORDS = '1000';


### PR DESCRIPTION
## Purpose
We should use constants instead of hardcoded value for query limits.

## Refs
https://issues.folio.org/browse/UICAL-185