### PR TITLE
UICAL-145: The "Online" checkbox is not centered vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix long exception periods display wrong days and subsequent exception periods display on the wrong days. Refs UICAL-175.
 * Improve grammar in pull request template. Refs UICAL-184.
 * Remove `react-dnd` and `react-dnd-html5-backend` by security vulnerability reason. Refs UICAL-182.
+* Fix spacing on exception modal service point picker. Refs UICAL-145.
 
 ## [7.0.0] (https://github.com/folio-org/ui-calendar/tree/v7.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v6.1.2...v7.0.0)

--- a/src/css/exception-form.css
+++ b/src/css/exception-form.css
@@ -1,5 +1,11 @@
-.CircleDiv{
+.servicePointSelectorRow {
+    /* important required to override List component of higher precedence */
+    justify-content: flex-start !important;
+}
+
+.circleDiv {
     border-radius: 50px;
     height: 15px;
     width: 15px;
+    margin-right: 0.5rem;
 }

--- a/src/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
+++ b/src/settings/OpenExceptionalForm/ExceptionalPeriodEditor.js
@@ -2,19 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Field,
-  reduxForm
+  reduxForm,
 } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
 
 import {
   Button,
-  Col,
-  Row,
   Checkbox,
+  Col,
   Datepicker,
-  TextField,
+  Label,
   List,
-  Timepicker
+  Row,
+  TextField,
+  Timepicker,
 } from '@folio/stripes/components';
 
 import { ALL_DAY } from '../constants';
@@ -138,8 +139,15 @@ class ExceptionalPeriodEditor extends React.Component {
 
     const items = this.state.servicePoints;
     const itemFormatter = (item) => (
-      <li data-test-service-point key={item.id}>
-        <div className="CircleDiv" style={{ background: item.color }} />
+      <li
+        data-test-service-point
+        key={item.id}
+        className="servicePointSelectorRow"
+      >
+        <div
+          className="circleDiv"
+          style={{ background: item.color }}
+        />
         <Checkbox
           id={item.id}
           label={item.name}
@@ -148,7 +156,6 @@ class ExceptionalPeriodEditor extends React.Component {
         />
       </li>
     );
-    const isEmptyMessage = 'No items to show';
     const allSelectorText = `ui-calendar.${allSelector ? 'selectAll' : 'deselectAll'}`;
 
     return (
@@ -203,13 +210,17 @@ class ExceptionalPeriodEditor extends React.Component {
         <Row>
           <Col>
             <div data-test-service-points>
-              <div data-test-service-points-title>
+              <Label
+                required
+                data-test-service-points-label
+              >
                 <FormattedMessage id="ui-calendar.settings.openingPeriodEnd" />
-              </div>
+              </Label>
               <List
                 items={items}
                 itemFormatter={itemFormatter}
-                isEmptyMessage={isEmptyMessage}
+                isEmptyMessage={<FormattedMessage id="ui-calendar.noServicePoints" />}
+                marginBottom0
               />
             </div>
           </Col>

--- a/src/settings/OpenExceptionalForm/ServicePointSelector.js
+++ b/src/settings/OpenExceptionalForm/ServicePointSelector.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Checkbox,
@@ -29,7 +30,7 @@ class ServicePointSelector extends React.Component {
     const itemFormatter = (item) => (
       <li data-test-service-point key={item.id}>
         <div
-          className="CircleDiv"
+          className="circleDiv"
           style={{ background: item.color }}
         />
         <Checkbox
@@ -41,14 +42,13 @@ class ServicePointSelector extends React.Component {
         />
       </li>
     );
-    const isEmptyMessage = 'No items to show';
 
     return (
       <div data-test-service-point-selector>
         <List
           items={items}
           itemFormatter={itemFormatter}
-          isEmptyMessage={isEmptyMessage}
+          isEmptyMessage={<FormattedMessage id="ui-calendar.noServicePoints" />}
         />
       </div>
     );

--- a/test/bigtest/interactors/ExeptionalForm.js
+++ b/test/bigtest/interactors/ExeptionalForm.js
@@ -32,7 +32,7 @@ import ConfirmationModal from './ConfirmationModal';
 @interactor class ServicePoints {
   defaultScope = '[data-test-service-points]';
 
-  title = scoped('[data-test-service-points-title]');
+  label = scoped('[data-test-service-points-label]');
   selectAllButton = scoped('[data-test-select-all]');
   items = collection('[data-test-service-point]', CheckboxInteractor);
 }

--- a/test/bigtest/tests/exceptional-form-test.js
+++ b/test/bigtest/tests/exceptional-form-test.js
@@ -105,9 +105,9 @@ describe('open exceptional form', () => {
               expect(calendarSettingsInteractor.exceptionalForm.exceptionalPeriodEditor.servicePoints.isPresent).to.be.true;
             });
 
-            it('should have proper title', () => {
-              expect(calendarSettingsInteractor.exceptionalForm.exceptionalPeriodEditor.servicePoints.title.text).to.equal(
-                translation['settings.openingPeriodEnd']
+            it('should have proper label', () => {
+              expect(calendarSettingsInteractor.exceptionalForm.exceptionalPeriodEditor.servicePoints.label.text).to.equal(
+                getRequiredLabel(translation['settings.openingPeriodEnd'], false)
               );
             });
 

--- a/translations/ui-calendar/en.json
+++ b/translations/ui-calendar/en.json
@@ -107,6 +107,7 @@
   "noEndDate": "Please set an end date.",
   "noName": "Please set a name.",
   "noServicePointSelected": "Please select at least one service point",
+  "noServicePoints": "No items to show",
   "noStartTime": "Please set start time",
   "noEndTime": "Please set end time",
   "endTimeBeforeStartTime": "The start time is after the end time!",
@@ -117,7 +118,6 @@
   "current": "Current:",
   "common.cancel": "Cancel",
   "intervalsOverlap": "Intervals can not overlap.",
-
   "permission.all": "Settings (Calendar): Can create, view, edit, and remove calendar events",
   "permission.view": "Settings (Calendar): Can view calendar events",
   "permission.edit": "Settings (Calendar): Can create, view, and edit calendar events"


### PR DESCRIPTION
## Purpose
Previously, the checkboxes to select the service point(s) for an exception had poor margins and looked strange.  This PR resolves these issues.

## Approach
All this does is resolve some margin and localization issues.

## Refs
https://issues.folio.org/browse/UICAL-145

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8005215/138941517-001eaeca-5c29-41f5-a77e-992641f11a4a.png)

After:
![image](https://user-images.githubusercontent.com/8005215/138941576-8759ee24-9f40-4b0e-bf18-e2c8cf22924b.png)