### PR TITLE
UICAL-176: fix issue Calendar hours displayed off by one day in Regul…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove `react-dnd` and `react-dnd-html5-backend` by security vulnerability reason. Refs UICAL-182.
 * Fix spacing on exception modal service point picker. Refs UICAL-145.
 * Use constant instead of hardcoded value for query limit. Refs UICAL-185.
+* Fix Calendar hours displayed off by one day in Regular hours Edit view. Refs UICAL-176.
 
 ## [7.0.2] (https://github.com/folio-org/ui-calendar/tree/v7.0.2) (2021-11-12)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.0.1...v7.0.2)

--- a/src/CalendarUtils.js
+++ b/src/CalendarUtils.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import moment from 'moment';
 
+import { getWeekDays } from './settings/utils/time';
+
 class CalendarUtils extends React.Component {
   static convertNewPeriodToValidBackendPeriod(period, event) {
-    const weekDays = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+    const weekDays = getWeekDays();
     let weekDay = 8;
     let openingHour = [];
     let sortedEvents = [];

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -36,7 +36,7 @@ class ExceptionWrapper extends Component {
   static propTypes = {
     entries: PropTypes.arrayOf(PropTypes.object),
     onClose: PropTypes.func.isRequired,
-    intl: PropTypes.object
+    intl: PropTypes.object,
   };
 
   constructor(props) {
@@ -76,6 +76,8 @@ class ExceptionWrapper extends Component {
       tempStart: null,
       tempClose: null
     });
+
+    moment.locale(props.intl.locale);
   }
 
   UNSAFE_componentWillMount() {      // eslint-disable-line react/no-deprecated, camelcase

--- a/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
+++ b/src/settings/OpenExceptionalForm/ExceptionalBigCalendar.js
@@ -1,12 +1,9 @@
 import React, { Component } from 'react';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import {
   Calendar,
-  momentLocalizer,
 } from 'react-big-calendar';
-
-const localizer = momentLocalizer(moment);
+import { localizer } from '../constants';
 
 class ExceptionalBigCalendar extends Component {
   static propTypes = {

--- a/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
+++ b/src/settings/OpeningPeriodForm/BigCalendarWrapper.js
@@ -2,18 +2,19 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
-import {
-  Calendar,
-  momentLocalizer,
-} from 'react-big-calendar';
+import { Calendar } from 'react-big-calendar';
+import { injectIntl } from 'react-intl';
 
-import { ALL_DAY } from '../constants';
+import {
+  ALL_DAY,
+  localizer,
+} from '../constants';
 import CalendarUtils from '../../CalendarUtils';
 import EventComponent from '../../components/EventComponent';
+import { getWeekDays } from '../utils/time';
 
 import style from './BigCalendarWrapper.css';
 
-const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(Calendar);
 
 class BigCalendarWrapper extends PureComponent {
@@ -21,6 +22,7 @@ class BigCalendarWrapper extends PureComponent {
     onCalendarChange: PropTypes.func.isRequired,
     periodEvents: PropTypes.arrayOf(PropTypes.object),
     eventsChange: PropTypes.func,
+    intl: PropTypes.object,
   };
 
   constructor(props) {
@@ -30,16 +32,19 @@ class BigCalendarWrapper extends PureComponent {
       eventIdCounter: 0,
       events: [],
     };
+
+    moment.locale(props.intl.locale);
   }
 
   componentDidMount() {
     const {
       periodEvents,
       eventsChange,
+      intl,
     } = this.props;
 
     if (periodEvents) {
-      const weekdays = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+      const weekDays = getWeekDays(intl.locale);
       const events = [];
       let eventId = 0;
 
@@ -49,13 +54,11 @@ class BigCalendarWrapper extends PureComponent {
           openingHour,
         },
         weekdays: {
-          day: weekday,
+          day: weekDay,
         },
       }) => {
         const event = {};
-        let eventDay = moment().startOf('week').toDate();
-
-        eventDay = moment(eventDay).add(weekdays.indexOf(weekday), 'day');
+        const eventDay = moment().startOf('week').add(weekDays.indexOf(weekDay), 'day');
         event.start = moment(eventDay);
         event.end = moment(eventDay);
         event.allDay = allDay;
@@ -229,4 +232,4 @@ class BigCalendarWrapper extends PureComponent {
     }
 }
 
-export default BigCalendarWrapper;
+export default injectIntl(BigCalendarWrapper);

--- a/src/settings/ServicePointDetails.js
+++ b/src/settings/ServicePointDetails.js
@@ -21,7 +21,15 @@ import ExceptionWrapper from './OpenExceptionalForm/ExceptionWrapper';
 import {
   permissions,
   ALL_DAY,
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+  SUNDAY,
 } from './constants';
+import { getWeekDays } from './utils/time';
 
 class ServicePointDetails extends React.Component {
   constructor(props) {
@@ -50,6 +58,8 @@ class ServicePointDetails extends React.Component {
       nextPeriods: [],
       isPeriodsPending: true,
     };
+
+    moment.locale(props.intl.locale);
   }
 
   componentDidMount() {
@@ -187,7 +197,8 @@ class ServicePointDetails extends React.Component {
   render() {
     let currentP;
     let currentPTimes;
-    const weekdays = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+    const weekDays = getWeekDays(this.props.intl.locale);
+
     if (this.state.currentPeriod) {
       currentP =
         <div data-test-service-point-current-period>
@@ -225,6 +236,37 @@ class ServicePointDetails extends React.Component {
           />
         </div>;
 
+      const weekDaysData = {
+        [SUNDAY]: {
+          columnTestProp: 'sunday',
+          labelId: 'sunDayShort',
+        },
+        [MONDAY]: {
+          columnTestProp: 'monday',
+          labelId: 'monDayShort',
+        },
+        [TUESDAY]: {
+          columnTestProp: 'tuesday',
+          labelId: 'tueDayShort',
+        },
+        [WEDNESDAY]: {
+          columnTestProp: 'wednesday',
+          labelId: 'wedDayShort',
+        },
+        [THURSDAY]: {
+          columnTestProp: 'thursday',
+          labelId: 'thuDayShort',
+        },
+        [FRIDAY]: {
+          columnTestProp: 'friday',
+          labelId: 'friDayShort',
+        },
+        [SATURDAY]: {
+          columnTestProp: 'saturday',
+          labelId: 'satDayShort',
+        },
+      };
+
       currentPTimes =
         <Row>
           <Col xs>
@@ -232,69 +274,26 @@ class ServicePointDetails extends React.Component {
               data-test-service-point-current-period-times
               className="seven-cols"
             >
-              <div
-                data-test-sunday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.sunDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[0])}
-                />
-              </div>
-              <div
-                data-test-monday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.monDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[1])}
-                />
-              </div>
-              <div
-                data-test-tuesday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.tueDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[2])}
-                />
-              </div>
-              <div
-                data-test-wednesday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.wedDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[3])}
-                />
-              </div>
-              <div
-                data-test-thursday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.thuDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[4])}
-                />
-              </div>
-              <div
-                data-test-friday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.friDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[5])}
-                />
-              </div>
-              <div
-                data-test-saturday
-                className="col-sm-1"
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-calendar.satDayShort" />}
-                  value={this.getWeekdayOpeningHours(weekdays[6])}
-                />
-              </div>
+              {weekDays.map((weekDay) => {
+                const weekDayData = weekDaysData[weekDay];
+                const columnTestProp = `data-test-${weekDayData.columnTestProp}`;
+                const columnDynamicProps = {
+                  [columnTestProp]: true,
+                };
+
+                return (
+                  <div
+                    key={weekDay}
+                    className="col-sm-1"
+                    {...columnDynamicProps}
+                  >
+                    <KeyValue
+                      label={<FormattedMessage id={`ui-calendar.${weekDayData.labelId}`} />}
+                      value={this.getWeekdayOpeningHours(weekDay)}
+                    />
+                  </div>
+                );
+              })}
             </div>
           </Col>
         </Row>;

--- a/src/settings/constants.js
+++ b/src/settings/constants.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import moment from 'moment';
+import { momentLocalizer } from 'react-big-calendar';
 
 export const colors = [
   '#3cb44b',
@@ -35,3 +37,13 @@ export const permissions = {
 export const ALL_DAY = <FormattedMessage id="ui-calendar.settings.allDay" />;
 
 export const MAX_RECORDS = '1000';
+
+export const localizer = momentLocalizer(moment);
+
+export const MONDAY = 'MONDAY';
+export const TUESDAY = 'TUESDAY';
+export const WEDNESDAY = 'WEDNESDAY';
+export const THURSDAY = 'THURSDAY';
+export const FRIDAY = 'FRIDAY';
+export const SATURDAY = 'SATURDAY';
+export const SUNDAY = 'SUNDAY';

--- a/src/settings/utils/time.js
+++ b/src/settings/utils/time.js
@@ -1,9 +1,39 @@
 import moment from 'moment';
 
+import {
+  localizer,
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+  SUNDAY,
+} from '../constants';
+
 // eslint-disable-next-line import/prefer-default-export
 export const setTimezoneOffset = (date) => {
   const momentDate = moment(date);
   const utcOffset = -(momentDate.utcOffset() / 60);
 
   return momentDate.add(utcOffset, 'hours');
+};
+
+/**
+ * Returns list of week days. First week day is based on user locale if locale is passed
+ * and SUNDAY if locale is not passed
+ * @param {string|null|undefined} locale - Locale code. Examples: en, en-US
+ * @returns {string[]} - List of week days. Example:
+ * ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY']
+ */
+export const getWeekDays = (locale) => {
+  const weekDays = [SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY];
+
+  if (!locale) {
+    return weekDays;
+  }
+
+  const movedDays = weekDays.splice(0, localizer.startOfWeek(locale));
+
+  return [...weekDays, ...movedDays];
 };


### PR DESCRIPTION
## Purpose
Fix issue Calendar hours displayed off by one day in Regular hours Edit view

## Approach
Original issue is related to used locale. For some locales(for example for **en-gb** locale) first day of week is **Monday**. And for some locales it is **Sunday**.

Source code expected that first day of week is always **Sunday** so it worked incorrectly for locales which had **Monday** as first day of week. [Current fix checks](https://github.com/folio-org/ui-calendar/pull/366/files#diff-af940d468ffafcad67560b1bbc67850aa0e8feb7bb1c52d0f01781ec49f44431R24) which first day of week(**Sunday** or **Monday**) must be used for current locale and works with it as first day of week.

Some more similar issues were found and fixed in this pull request. These issues are related to used locale and **moment**. The list of these issues can be found here in [this comment](https://issues.folio.org/browse/UICAL-189?focusedCommentId=116754&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-116754)

Current locale must be set to **moment** and it fixes the issues. I believe current locale must be set to **moment** only once in one place in the whole application but it must be discussed. Currently in this pull request we do the same thing like some **stripes-components** do, for example in **datepicker** you can see that it sets locale to **moment**
https://github.com/folio-org/stripes-components/blob/master/lib/Datepicker/Datepicker.js#L20
As I said I believe it is not right to do like this and we have to set locale to the **moment** once in one place in the application but currently we can fix these issues only setting locale to the **moment** in every place where it is used.

## Refs
https://issues.folio.org/browse/UICAL-176

