### PR TITLE
UICAL-193: Show translated error message when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix spacing on exception modal service point picker. Refs UICAL-145.
 * Use constant instead of hardcoded value for query limit. Refs UICAL-185.
 * Fix Calendar hours displayed off by one day in Regular hours Edit view. Refs UICAL-176.
+* Localize error message modal.  Refs UICAL-193.
 
 ## [7.0.2] (https://github.com/folio-org/ui-calendar/tree/v7.0.2) (2021-11-12)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.0.1...v7.0.2)

--- a/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
+++ b/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
@@ -123,13 +123,18 @@ class OpeningPeriodFormWrapper extends Component {
     });
   }
 
-  catchOverlappedEvents = async err => {
-    if (err.status === 422) {
+  catchOverlappedEvents = async (err) => {
+    if (err.status >= 400) {
       const response = await err.json();
-      const errorMessage = response.errors[0].message;
+      const error = response.errors[0];
 
       this.setState({
-        errorModalText: errorMessage,
+        errorModalText: (
+          <FormattedMessage
+            id={`ui-calendar.${error.code}`}
+            defaultMessage={error.message}
+          />
+        ),
       });
     }
   };


### PR DESCRIPTION
## Purpose
The error message modal for errors sent from the server (such as overlapping periods) was not properly translated, despite translations already existing.

## Approach
This uses the error's code and message, as sent by the server, instead of merely using the error message provided.  The error code sent by the server, `intervalsOverlap`, corresponds to a translation, however, this translation was not actually used.

This fix uses a `<FormattedMessage>` component which will attempt to use the error code as a translation ID and, if it does not exist, use the error message provided by the server.

Since the goal of this was to make the error modal more generic, a `>= 400` status code is required, rather than `=== 422`.  This allows any client/server error to be displayed with this modal (although currently, the only real applicable one is the overlapping interval).

## Refs
https://issues.folio.org/projects/UICAL/issues/UICAL-193?filter=allissues

## Screenshots
The issue:

![issue](https://issues.folio.org/secure/attachment/42798/42798_image-2021-12-02-13-49-01-839.png)

Sample payload from the server:
![image](https://user-images.githubusercontent.com/8005215/144500652-2679c5b0-e126-427a-aac1-15d89e5b1eee.png)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] ~~If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly~~
  - [x] There are no breaking changes in this PR.
