### PR TITLE
UICAL-179: User can save empty "Name" field in editing Exception Period page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix spacing on exception modal service point picker. Refs UICAL-145.
 * Use constant instead of hardcoded value for query limit. Refs UICAL-185.
 * Fix Calendar hours displayed off by one day in Regular hours Edit view. Refs UICAL-176.
+* User can save empty "Name" field in editing Exception Period page. Refs UICAL-179.
 
 ## [7.0.2] (https://github.com/folio-org/ui-calendar/tree/v7.0.2) (2021-11-12)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.0.1...v7.0.2)

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import RandomColor from 'randomcolor';
 import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty } from 'lodash';
+import {
+  isEmpty,
+} from 'lodash';
 
 import {
   Button,
@@ -994,21 +996,21 @@ class ExceptionWrapper extends Component {
         isServicePointSelected = true;
       }
     }
-    if (startDate === null || startDate === undefined || startDate === '') {
+    if (isEmpty(startDate)) {
       errorMessage = 'noStartDate';
-    } else if (endDate === null || endDate === undefined || endDate === '') {
+    } else if (isEmpty(endDate)) {
       errorMessage = 'noEndDate';
     } else if (moment(endDate)
       .toDate() < moment(startDate)
       .toDate()) {
       errorMessage = 'wrongStartEndDate';
-    } else if (name === null || name === undefined) {
+    } else if (isEmpty(name)) {
       errorMessage = 'noName';
     } else if (!isServicePointSelected) {
       errorMessage = 'noServicePointSelected';
-    } else if (startTime === null || startTime === undefined || startTime === '') {
+    } else if (isEmpty(startTime)) {
       errorMessage = 'noStartTime';
-    } else if (endTime === null || endTime === undefined || endTime === '') {
+    } else if (isEmpty(endTime)) {
       errorMessage = 'noEndTime';
     } else if (moment(endTime) < moment(startTime)) {
       errorMessage = 'endTimeBeforeStartTime';


### PR DESCRIPTION
## Purpose
Fix issue when user can save empty "Name" field in editing Exception Period page.

## Refs
https://issues.folio.org/browse/UICAL-179

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/145165087-83be636a-62fd-4c89-80f4-987f3c8b4e72.png)