### PR TITLE
UICAL-196: Fix default exception closure value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## IN PROGRESS
+
+* Fix exceptional defaults for opening/closure. Refs UICAL-196
+
 ## [7.1.0] (https://github.com/folio-org/ui-calendar/tree/v7.1.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.0.2...v7.1.0)
 

--- a/src/settings/OpenExceptionalForm/ExceptionWrapper.js
+++ b/src/settings/OpenExceptionalForm/ExceptionWrapper.js
@@ -800,7 +800,7 @@ class ExceptionWrapper extends Component {
                     }
                   ],
                   allDay: allDay === undefined ? false : allDay,
-                  open: closed === undefined ? false : !closed,    // form asked for closed tag but backed expect open so closed state store the velue for the backend
+                  open: closed === undefined ? true : !closed,    // form asked for closed tag but backed expect open so closed state store the value for the backend
                 }
               }]
             };
@@ -810,10 +810,10 @@ class ExceptionWrapper extends Component {
         }
       } else if (exceptionalIds.length) {
         for (let i = 0; i < exceptionalIds.length; i++) {
-          const chekedId = exceptionalIds[i].servicePointId;
+          const checkedId = exceptionalIds[i].servicePointId;
           let action = 'POST';
           for (let j = 0; j < editorServicePoints.length; j++) {
-            if (editorServicePoints[j].id === chekedId) {
+            if (editorServicePoints[j].id === checkedId) {
               if (editorServicePoints[j].selected === false) {
                 action = 'DELETE';
               } else {
@@ -845,7 +845,7 @@ class ExceptionWrapper extends Component {
                     }
                   ],
                   allDay: allDay === undefined ? false : allDay,
-                  open: closed === undefined ? false : !closed,    // form asked for closed tag but backed expect open so closed state store the velue for the backend
+                  open: closed === undefined ? true : !closed,    // form asked for closed tag but backed expect open so closed state store the value for the backend
                 }
               }]
             };
@@ -867,12 +867,12 @@ class ExceptionWrapper extends Component {
                     }
                   ],
                   allDay: allDay === undefined ? false : allDay,
-                  open: closed === undefined ? false : !closed,    // form asked for closed tag but backed expect open so closed state store the velue for the backend
+                  open: closed === undefined ? true : !closed,    // form asked for closed tag but backed expect open so closed state store the value for the backend
                 }
               }]
             };
-            const modifyPromisPost = periods.POST(modifyExceptionPost);
-            promises.push(modifyPromisPost);
+            const modifyPromisePost = periods.POST(modifyExceptionPost);
+            promises.push(modifyPromisePost);
           }
         }
       }


### PR DESCRIPTION
## Purpose

By default, when creating an exception, the "closed" box is unchecked.  However, when the box has not been interacted with (so its state is `undefined`), the current code treated this as `open = false`, however, the opposite should be true (as the checkbox denotes the opposite of the `open` attribute.

## Approach

This simply changes the default value for when the closed box is `undefined` to mean `open=true`, which is desired.

A few typos were also fixed in the same file, however, these made no functional difference.

## Refs

[UICAL-196](https://issues.folio.org/browse/UICAL-196?focusedCommentId=125065&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-125065)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes? **No.**
