### PR TITLE
UICAL-193: Improve Error Modal Localization/Versatility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## IN PROGRESS
+
+* More versatile error modals.  Refs UICAL-193.
+
 ## [7.1.1] (https://github.com/folio-org/ui-calendar/tree/v7.1.1) (2022-03-13)
 [Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.1.0...v7.1.1)
 

--- a/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
+++ b/src/settings/OpeningPeriodForm/OpeningPeriodFormWrapper.js
@@ -123,8 +123,8 @@ class OpeningPeriodFormWrapper extends Component {
     });
   }
 
-  catchOverlappedEvents = async err => {
-    if (err.status === 422) {
+  catchOverlappedEvents = async (err) => {
+    if (err.status >= 400) {
       const response = await err.json();
       const errorMessage = response.errors[0].message;
 
@@ -309,7 +309,7 @@ class OpeningPeriodFormWrapper extends Component {
           dismissible
           onClose={this.closeErrorModal}
           open
-          label={<FormattedMessage id="ui-calendar.invalidData" />}
+          label={<FormattedMessage id="ui-calendar.saveError" />}
           footer={footer}
         >
           <div data-test-error-modal-content>


### PR DESCRIPTION
## Purpose
The error message modal for errors sent from the server (such as overlapping periods) would only show if a `422` HTTP code was returned, rather than a more generic 4xx or 5xx code.  Additionally, the title showed a localized "Invalid Data", regardless of the error itself.

## Approach
This changes the required `=== 422` status check to `>= 400`, allowing any client/server error to be displayed with this modal.  It also changes the title to display "Error" through the translation key for `saveError`, being more generic than "Invalid Data".

The localization of the messages themselves is part of [MODCAL-107](https://issues.folio.org/browse/MODCAL-107) and this must be merged first before the MODCAL-107 PR.

## Refs
https://issues.folio.org/projects/UICAL/issues/UICAL-193?filter=allissues

## Screenshots
The issue:

![issue](https://issues.folio.org/secure/attachment/42798/42798_image-2021-12-02-13-49-01-839.png)

Sample payload from the server:
![image](https://user-images.githubusercontent.com/8005215/144500652-2679c5b0-e126-427a-aac1-15d89e5b1eee.png)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] ~~If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly~~
  - [x] There are no breaking changes in this PR.
