### PR TITLE
UICAL-230: Fixed display of service point in Library Hours.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for ui-calendar
 
-## [7.2.0] (https://github.com/folio-org/ui-calendar/tree/v7.1.1) (2022-06-25)
+## IN PROGRESS
+* Fixed display of service point in Library Hours. Refs UICAL-230.
+
+## [7.2.0] (https://github.com/folio-org/ui-calendar/tree/v7.2.0) (2022-06-25)
+[Full Changelog](https://github.com/folio-org/ui-calendar/compare/v7.1.1...v7.2.0)
 
 * Refactor away from `react-intl-safe-html`. Refs UICAL-142.
 * Update NodeJS to v16 in GitHub Actions. Refs UICAL-202.

--- a/src/settings/LibraryHours.js
+++ b/src/settings/LibraryHours.js
@@ -13,7 +13,7 @@ class LibraryHours extends React.Component {
       entries: {
         type: 'okapi',
         records: 'servicepoints',
-        perRequest: 100,
+        perRequest: MAX_RECORDS,
         path: 'service-points',
         params: {
           query: 'cql.allRecords=1',

--- a/src/settings/constants.js
+++ b/src/settings/constants.js
@@ -36,7 +36,7 @@ export const permissions = {
 
 export const ALL_DAY = <FormattedMessage id="ui-calendar.settings.allDay" />;
 
-export const MAX_RECORDS = '1000';
+export const MAX_RECORDS = '10000';
 
 export const localizer = momentLocalizer(moment);
 


### PR DESCRIPTION
## Purpose
Fixed display of service point in Library Hours.

## Approach 
- Use MAX_RECORDS instead of 100 for getting all data. 
- Increased MAX_RECORDS to 10000 for consistency (https://github.com/folio-org/ui-users/blob/master/src/constants.js#L65).
- Minor updates to CHANGELOG.md have been added.

## Refs
https://issues.folio.org/browse/UICAL-230