### PR TITLE
UICAL-199 remove react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "prettier": "^2.7.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hot-loader": "^4.3.12",
     "react-intl": "^5.7.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import type { SettingsProps } from '@folio/stripes/smart-components';
 import type { FunctionComponent } from 'react';
 import React from 'react';
-import { hot } from 'react-hot-loader';
 import Settings from './views';
 
 const CalendarRouting: FunctionComponent<SettingsProps> = (props) => {
@@ -20,4 +19,4 @@ const CalendarRouting: FunctionComponent<SettingsProps> = (props) => {
   }
 };
 
-export default hot(module)(CalendarRouting);
+export default CalendarRouting;


### PR DESCRIPTION
Remove `react-hot-loader`. Comments on the Jira ticket notwithstanding, the rewrite did not address this issue. 

@ncovercash, does Steven Turner have a GitHub account I can/should add for review? I see this ticket was assigned to him in Jira.

Refs [UICAL-199](https://issues.folio.org/browse/UICAL-199)
