### PR TITLE
Convert JS tests to TSX and add await as applicable

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@formatjs/cli": "^4.2.21",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
-    "@testing-library/user-event": "^12",
+    "@testing-library/user-event": "^14.4.3",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "babel-polyfill": "^6.26.0",

--- a/src/components/fields/OpenClosedSelect.test.tsx
+++ b/src/components/fields/OpenClosedSelect.test.tsx
@@ -41,7 +41,7 @@ describe('OpenClosedSelect', () => {
     expect(screen.getByText('Closed')).toBeInTheDocument();
   });
 
-  it('calls onBlur and onChange callbacks', () => {
+  it('calls onBlur and onChange callbacks', async () => {
     const onBlur = jest.fn();
     const onChange = jest.fn();
 
@@ -54,7 +54,7 @@ describe('OpenClosedSelect', () => {
         />
       )
     );
-    userEvent.selectOptions(screen.getByRole('combobox'), [RowType.Open]);
+    await userEvent.selectOptions(screen.getByRole('combobox'), [RowType.Open]);
 
     expect(onBlur).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalled();

--- a/src/components/fields/OpenClosedSelect.test.tsx
+++ b/src/components/fields/OpenClosedSelect.test.tsx
@@ -11,7 +11,15 @@ describe('OpenClosedSelect', () => {
     const onBlur = jest.fn();
     const onChange = jest.fn();
 
-    render(withIntlConfiguration(<OpenClosedSelect onBlur={onBlur} onChange={onChange} />));
+    render(
+      withIntlConfiguration(
+        <OpenClosedSelect
+          onBlur={onBlur}
+          onChange={onChange}
+          value={RowType.Open}
+        />
+      )
+    );
 
     expect(screen.getByText('Open')).toBeInTheDocument();
   });
@@ -20,7 +28,15 @@ describe('OpenClosedSelect', () => {
     const onBlur = jest.fn();
     const onChange = jest.fn();
 
-    render(withIntlConfiguration(<OpenClosedSelect onBlur={onBlur} onChange={onChange} />));
+    render(
+      withIntlConfiguration(
+        <OpenClosedSelect
+          onBlur={onBlur}
+          onChange={onChange}
+          value={RowType.Open}
+        />
+      )
+    );
 
     expect(screen.getByText('Closed')).toBeInTheDocument();
   });
@@ -29,7 +45,15 @@ describe('OpenClosedSelect', () => {
     const onBlur = jest.fn();
     const onChange = jest.fn();
 
-    render(withIntlConfiguration(<OpenClosedSelect onBlur={onBlur} onChange={onChange} />));
+    render(
+      withIntlConfiguration(
+        <OpenClosedSelect
+          onBlur={onBlur}
+          onChange={onChange}
+          value={RowType.Open}
+        />
+      )
+    );
     userEvent.selectOptions(screen.getByRole('combobox'), [RowType.Open]);
 
     expect(onBlur).toHaveBeenCalled();

--- a/src/components/fields/WeekdayPicker.test.tsx
+++ b/src/components/fields/WeekdayPicker.test.tsx
@@ -7,13 +7,17 @@ import * as Weekdays from '../../test/data/Weekdays';
 import WeekdayPicker from './WeekdayPicker';
 
 describe('WeekdayPicker', () => {
-  it('correctly calls props.onChange', () => {
+  it('correctly calls props.onChange', async () => {
     const day = Weekdays.Sunday;
     const onChange = jest.fn();
-    render(withIntlConfiguration(<WeekdayPicker onChange={onChange} />));
+    render(
+      withIntlConfiguration(
+        <WeekdayPicker value={undefined} onChange={onChange} />
+      )
+    );
 
-    userEvent.selectOptions(screen.getByRole('combobox'), [day]);
-    userEvent.selectOptions(screen.getByRole('combobox'), ['']);
+    await userEvent.selectOptions(screen.getByRole('combobox'), [day]);
+    await userEvent.selectOptions(screen.getByRole('combobox'), ['']);
 
     expect(onChange).toHaveBeenNthCalledWith(1, day);
     expect(onChange).toHaveBeenNthCalledWith(2, undefined);

--- a/src/forms/PurgeModal.test.tsx
+++ b/src/forms/PurgeModal.test.tsx
@@ -4,17 +4,22 @@ import userEvent from '@testing-library/user-event';
 
 import withIntlConfiguration from '../test/util/withIntlConfiguration';
 import PurgeModal from './PurgeModal';
+import DataRepository from '../data/DataRepository';
 
 describe('PurgeModal', () => {
-  it('correctly calls props.onClose', () => {
+  it('correctly calls props.onClose', async () => {
     const onClose = jest.fn();
     const dataRepository = {
-      getCalendars: jest.fn(),
-    };
+      getCalendars: jest.fn()
+    } as unknown as DataRepository;
 
-    render(withIntlConfiguration(<PurgeModal onClose={onClose} open dataRepository={dataRepository} />));
+    render(
+      withIntlConfiguration(
+        <PurgeModal onClose={onClose} open dataRepository={dataRepository} />
+      )
+    );
 
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/forms/PurgeModal.tsx
+++ b/src/forms/PurgeModal.tsx
@@ -222,14 +222,12 @@ export const PurgeModal: FunctionComponent<PurgeModalProps> = (
                     <FormattedMessage id="ui-calendar.purgeModal.deletionList.label" />
                   }
                   closedByDefault
-                  headerProps={{
-                    displayWhenClosed: (
-                      <Badge color="default">{toPurge.length}</Badge>
-                    ),
-                    displayWhenOpen: (
-                      <Badge color="default">{toPurge.length}</Badge>
-                    )
-                  }}
+                  displayWhenClosed={
+                    <Badge color="default">{toPurge.length}</Badge>
+                  }
+                  displayWhenOpen={
+                    <Badge color="default">{toPurge.length}</Badge>
+                  }
                 >
                   <List
                     items={toPurge.map((c) => c.name)}

--- a/src/views/CalendarSettings.test.tsx
+++ b/src/views/CalendarSettings.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { SettingsProps } from '@folio/stripes/smart-components';
 import CalendarSettings from './CalendarSettings';
 
 jest.mock('@folio/stripes-smart-components/lib/Settings', () => jest.fn().mockReturnValue('Settings'));
 
-const renderCalendarSettings = () => render(<CalendarSettings />);
+const renderCalendarSettings = () => render(<CalendarSettings {...({} as unknown as SettingsProps)} />);
 
 describe('Calender Settings', () => {
   it('should render Calendar Settings', () => {


### PR DESCRIPTION
Adds `await` where needed to tests that use `userEvents`.  This prevents various timing errors which caused intermittent test failures.

Bundled with this is also a fix for PurgeModal, which was passing various header props incorrectly.