### PR TITLE
UICAL-206 test AllCalendarView

### DIFF
--- a/src/test/__mocks__/stripes-core.mock.ts
+++ b/src/test/__mocks__/stripes-core.mock.ts
@@ -1,4 +1,110 @@
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes-core'),
-  useOkapiKy: jest.fn()
-}));
+// jest.mock('@folio/stripes/core', () => ({
+//   ...jest.requireActual('@folio/stripes-core'),
+//   useOkapiKy: jest.fn(),
+//   useStripes: () => ({
+//     hasPerm: jest.fn().mockReturnValue(true),
+//   })
+// }));
+
+jest.mock('@folio/stripes/core', () => {
+  const STRIPES = {
+    actionNames: [],
+    bindings: {},
+    clone: jest.fn(),
+    config: {
+      logCategories: '',
+      logPrefix: '',
+      logTimestamp: true,
+      showPerms: true,
+      showHomeLink: true,
+      listInvisiblePerms: true,
+      disableAuth: false,
+      hasAllPerms: false,
+    },
+    currency: 'USD',
+    discovery: {
+      interfaces: {},
+      isFinished: true,
+      modules: {},
+      okapi: {},
+    },
+    epics: {
+      add: jest.fn(),
+      middleware: jest.fn(),
+    },
+    hasInterface: () => true,
+    hasPerm: () => true,
+    icons: {},
+    locale: 'en-US',
+    logger: {
+      log: () => {},
+    },
+    metadata: {},
+    okapi: {
+      authFailure: false,
+      okapiReady: true,
+      tenant: 'diku',
+      token: 'c0ffee',
+      translations: {
+        'stripes-components.Datepicker.calendar': 'calendar',
+        'stripes-components.Datepicker.calendarDaysList': 'calendar days list.',
+        'stripes-core.button.cancel': [{ type: 0, value: 'Cancel' }],
+        'ui-users.permission.modal.list.pane.header': 'Permissions',
+        'ui-users.permission.modal.list.pane.header.array': [{ type: 0, value: 'Permissions' }],
+        default: false,
+      },
+      url: 'https://folio-testing-okapi.dev.folio.org',
+      withoutOkapi: false,
+    },
+    plugins: {},
+    setBindings: jest.fn(),
+    setCurrency: jest.fn(),
+    setLocale: jest.fn(),
+    setSinglePlugin: jest.fn(),
+    setTimezone: jest.fn(),
+    setToken: jest.fn(),
+    store: {
+      getState: () => ({
+        okapi: {
+          token: 'abc',
+        },
+      }),
+      dispatch: () => {},
+      subscribe: () => {},
+      replaceReducer: () => {},
+    },
+    timezone: 'UTC',
+    user: {
+      perms: {},
+      user: {
+        addresses: [],
+        firstName: 'Testy',
+        lastName: 'McTesterson',
+        email: 'test@folio.org',
+        id: 'b1add99d-530b-5912-94f3-4091b4d87e2c',
+        username: 'diku_admin',
+      },
+    },
+    withOkapi: true,
+  };
+
+  return {
+    ...jest.requireActual('@folio/stripes/core'),
+    IfInterface: jest.fn(({ name, children }) => {
+      return name === 'interface' || name === 'service-points-users' ? children : null;
+    }),
+    IfPermission: jest.fn(({ perm, children }) => {
+      if (perm === 'permission') {
+        return children;
+      } else if (perm.startsWith('ui-calendar')) {
+        return children;
+      } else if (perm.startsWith('perms')) {
+        return children;
+      } else {
+        return null;
+      }
+    }),
+    Pluggable: jest.fn(({ children }) => [children]),
+    useStripes: () => STRIPES,
+  };
+});

--- a/src/test/__mocks__/stripes-core.mock.ts
+++ b/src/test/__mocks__/stripes-core.mock.ts
@@ -1,91 +1,6 @@
-// jest.mock('@folio/stripes/core', () => ({
-//   ...jest.requireActual('@folio/stripes-core'),
-//   useOkapiKy: jest.fn(),
-//   useStripes: () => ({
-//     hasPerm: jest.fn().mockReturnValue(true),
-//   })
-// }));
-
 jest.mock('@folio/stripes/core', () => {
   const STRIPES = {
-    actionNames: [],
-    bindings: {},
-    clone: jest.fn(),
-    config: {
-      logCategories: '',
-      logPrefix: '',
-      logTimestamp: true,
-      showPerms: true,
-      showHomeLink: true,
-      listInvisiblePerms: true,
-      disableAuth: false,
-      hasAllPerms: false,
-    },
-    currency: 'USD',
-    discovery: {
-      interfaces: {},
-      isFinished: true,
-      modules: {},
-      okapi: {},
-    },
-    epics: {
-      add: jest.fn(),
-      middleware: jest.fn(),
-    },
-    hasInterface: () => true,
     hasPerm: () => true,
-    icons: {},
-    locale: 'en-US',
-    logger: {
-      log: () => {},
-    },
-    metadata: {},
-    okapi: {
-      authFailure: false,
-      okapiReady: true,
-      tenant: 'diku',
-      token: 'c0ffee',
-      translations: {
-        'stripes-components.Datepicker.calendar': 'calendar',
-        'stripes-components.Datepicker.calendarDaysList': 'calendar days list.',
-        'stripes-core.button.cancel': [{ type: 0, value: 'Cancel' }],
-        'ui-users.permission.modal.list.pane.header': 'Permissions',
-        'ui-users.permission.modal.list.pane.header.array': [{ type: 0, value: 'Permissions' }],
-        default: false,
-      },
-      url: 'https://folio-testing-okapi.dev.folio.org',
-      withoutOkapi: false,
-    },
-    plugins: {},
-    setBindings: jest.fn(),
-    setCurrency: jest.fn(),
-    setLocale: jest.fn(),
-    setSinglePlugin: jest.fn(),
-    setTimezone: jest.fn(),
-    setToken: jest.fn(),
-    store: {
-      getState: () => ({
-        okapi: {
-          token: 'abc',
-        },
-      }),
-      dispatch: () => {},
-      subscribe: () => {},
-      replaceReducer: () => {},
-    },
-    timezone: 'UTC',
-    user: {
-      perms: {},
-      user: {
-        addresses: [],
-        firstName: 'Testy',
-        lastName: 'McTesterson',
-        email: 'test@folio.org',
-        id: 'b1add99d-530b-5912-94f3-4091b4d87e2c',
-        username: 'diku_admin',
-      },
-    },
-    withOkapi: true,
   };
 
   return {
@@ -105,6 +20,7 @@ jest.mock('@folio/stripes/core', () => {
       }
     }),
     Pluggable: jest.fn(({ children }) => [children]),
+    useOkapiKy: jest.fn(),
     useStripes: () => STRIPES,
   };
 });

--- a/src/test/util/withHistoryConfiguration.tsx
+++ b/src/test/util/withHistoryConfiguration.tsx
@@ -1,0 +1,56 @@
+import stripesComponentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
+import stripesCoreTranslations from '@folio/stripes-core/translations/stripes-core/en';
+import React, { ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+// cannot make TS happy without the .json
+// eslint-disable-next-line import/extensions
+import localTranslations from '../../../translations/ui-calendar/en.json';
+
+const translationSets = [
+  {
+    prefix: 'ui-calendar',
+    translations: localTranslations,
+  },
+  {
+    prefix: 'stripes-components',
+    translations: stripesComponentsTranslations,
+  },
+  {
+    prefix: 'stripes-core',
+    translations: stripesCoreTranslations,
+  },
+];
+
+function withHistoryConfiguration(
+  children: ReactNode,
+  locale = 'en-US',
+  timeZone = 'UTC'
+): JSX.Element {
+  const allTranslations: Record<string, string> = {};
+
+  translationSets.forEach((set) => {
+    const { prefix, translations } = set;
+    Object.keys(translations).forEach((key) => {
+      allTranslations[`${prefix}.${key}`] = translations[key];
+    });
+  });
+
+  const history = createMemoryHistory();
+
+  return (
+    <Router history={history}>
+      <IntlProvider
+        locale={locale}
+        timeZone={timeZone}
+        messages={allTranslations}
+      >
+        {children}
+      </IntlProvider>
+    </Router>
+  );
+}
+
+export default withHistoryConfiguration;

--- a/src/views/AllCalendarView.test.js
+++ b/src/views/AllCalendarView.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// import { useStripes } from '@folio/stripes/core';
+import AllCalendarView from './AllCalendarView';
+
+import useDataRepository from '../data/useDataRepository';
+import withHistoryConfiguration from '../test/util/withHistoryConfiguration';
+
+jest.mock('../data/useDataRepository');
+// jest.mock('@folio/stripes/core');
+
+describe('AllCalendarView', () => {
+  describe('renders a loading pane', () => {
+    beforeEach(() => {
+      const mockUseDataRepository = useDataRepository;
+      mockUseDataRepository.mockReturnValue({
+        isLoaded: () => false,
+      });
+    });
+
+    it('renders', () => {
+      render(withHistoryConfiguration(<AllCalendarView />));
+      expect(screen.getByText('All calendars')).toBeInTheDocument();
+    });
+  });
+
+  describe('correctly populates action menu', () => {
+    beforeEach(() => {
+      const mockUseDataRepository = useDataRepository;
+      mockUseDataRepository.mockReturnValue({
+        isLoaded: () => true,
+        getCalendars: () => [],
+      });
+    });
+
+    it('renders action-menu buttons when menu is open', async () => {
+      render(withHistoryConfiguration(<AllCalendarView />));
+
+      await userEvent.click(screen.getByRole('button'));
+      const buttons = await screen.findAllByRole('button');
+      expect(buttons).toHaveLength(3);
+    });
+  });
+});
+

--- a/src/views/AllCalendarView.tsx
+++ b/src/views/AllCalendarView.tsx
@@ -39,7 +39,7 @@ const AllCalendarView: FunctionComponent<Record<string, never>> = () => {
   )?.params?.calendarId;
 
   if (!dataRepository.isLoaded()) {
-    return <LoadingPane paneTitle="All calendars" />;
+    return <LoadingPane paneTitle={intl.formatMessage({ id: 'ui-calendar.allCalendarView.title' })} />;
   }
 
   const rows = dataRepository.getCalendars().map((calendar) => {


### PR DESCRIPTION
Test `./src/views/AllCalendarView`.

* Elaborate stripes-core mock copied mostly verbatim from ui-users, minus a few things TS barfed on.
* `withHistoryConfiguration` mirrors `withIntlConfiguration` but provides a react-router provider.
* Minor bug fix: localize the "All calendars" pane title

Refs [UICAL-206](https://issues.folio.org/browse/UICAL-206)