### PR TITLE
UICAL-233 supply missing interface in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     ],
     "okapiInterfaces": {
       "calendar": "5.0",
-      "service-points": "3.0"
+      "service-points": "3.0",
+      "users": "16.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
`useDataRepository` queries `/users` but that interface was not listed in `okapiInterfaces` in `package.json`.

Refs [UICAL-233](https://issues.folio.org/browse/UICAL-233)
