### PR TITLE
restore @types/* to direct deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,8 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@types/memoizee": "^0.4.8",
+    "@types/react-router-dom": "^5.2.0",
     "classnames": "^2.3.1",
     "dayjs": "^1.11.2",
     "dom-helpers": "^5.2.1",


### PR DESCRIPTION
Restore direct `@types` deps that were moved to dev-deps in #439. This modules is _not_ transpiled upon release; rather, it is transpiled when building a bundle. Hence, the dependencies relevant to transpilation must be available to the bundler (i.e. must be available when platform-level dependencies are installed) and thus must be listed here as direct deps.