### PR TITLE
UICAL-243: Fix eslint dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-calendar ./translations/ui-calendar/compiled"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "https://github.com/folio-org/eslint-config-stripes.git#master",
+    "@folio/eslint-config-stripes": "^6.3.0",
     "@folio/stripes": "^7.2.0",
     "@folio/stripes-cli": "^2.6.0",
     "@folio/stripes-components": "^10.2.0",


### PR DESCRIPTION
A little more of [UICAL-243](https://issues.folio.org/projects/UICAL/issues/UICAL-243?filter=allissues) to fix the `eslint-config-stripes` version