### PR TITLE
UICAL-205: Fix monthly view date calculations

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 import { FormattedDate, useIntl } from 'react-intl';
 import { CSSPropertiesWithVars } from '../types/css';
 import { getDateArray } from '../utils/CalendarUtils';
-import { dateToYYYYMMDD, isSameMonth } from '../utils/DateUtils';
+import { dateUTCToYYYYMMDD, isSameUTCMonth } from '../utils/DateUtils';
 import { LocaleWeekdayInfo, useLocaleWeekdays } from '../utils/WeekdayUtils';
 import css from './Calendar.css';
 
@@ -31,7 +31,7 @@ export default function Calendar(props: Props) {
 
   const displayDates = getDateArray(intl.locale, monthBasis).map(
     (date: Date) => {
-      const dateString = dateToYYYYMMDD(date);
+      const dateString = dateUTCToYYYYMMDD(date);
       let contents: ReactNode = <Loading />;
       if (dateString in events) {
         contents = events[dateString];
@@ -40,13 +40,13 @@ export default function Calendar(props: Props) {
       return (
         <div
           className={classNames(
-            isSameMonth(date, monthBasis) ? '' : css.adjacentMonth,
+            isSameUTCMonth(date, monthBasis) ? '' : css.adjacentMonth,
             css.calendarDay
           )}
-          key={dateToYYYYMMDD(date)}
+          key={dateUTCToYYYYMMDD(date)}
         >
           <span key="label" className={css.dayLabel}>
-            <FormattedDate value={date} day="numeric" />
+            <FormattedDate value={date} day="numeric" timeZone="UTC" />
           </span>
           {contents}
         </div>
@@ -67,17 +67,26 @@ export default function Calendar(props: Props) {
         <IconButton
           icon="arrow-left"
           onClick={() => setMonthBasis(
-            new Date(new Date(monthBasis).setMonth(monthBasis.getMonth() - 1))
+            new Date(
+              new Date(monthBasis).setUTCMonth(monthBasis.getUTCMonth() - 1)
+            )
           )
           }
         />
         <Headline size="xx-large" margin="none">
-          <FormattedDate value={monthBasis} month="long" year="numeric" />
+          <FormattedDate
+            value={monthBasis}
+            month="long"
+            year="numeric"
+            timeZone="UTC"
+          />
         </Headline>
         <IconButton
           icon="arrow-right"
           onClick={() => setMonthBasis(
-            new Date(new Date(monthBasis).setMonth(monthBasis.getMonth() + 1))
+            new Date(
+              new Date(monthBasis).setUTCMonth(monthBasis.getUTCMonth() + 1)
+            )
           )
           }
         />

--- a/src/data/DataRepository.ts
+++ b/src/data/DataRepository.ts
@@ -6,7 +6,7 @@ import {
   ServicePoint,
   User
 } from '../types/types';
-import { dateToYYYYMMDD } from '../utils/DateUtils';
+import { dateUTCToYYYYMMDD } from '../utils/DateUtils';
 import { ServicePointDTO } from './types';
 
 const getServicePointMap = memoizee(
@@ -146,8 +146,8 @@ export default class DataRepository {
   ): Promise<DailyOpeningInfo[]> {
     return this.mutators.dates({
       servicePointId,
-      startDate: dateToYYYYMMDD(startDate),
-      endDate: dateToYYYYMMDD(endDate)
+      startDate: dateUTCToYYYYMMDD(startDate),
+      endDate: dateUTCToYYYYMMDD(endDate)
     });
   }
 

--- a/src/test/data/Dates.ts
+++ b/src/test/data/Dates.ts
@@ -3,64 +3,85 @@ import dayjs from '../../utils/dayjs';
 /** Saturday */
 export const JAN_1 = dayjs('2000-01-01').utc(true);
 export const JAN_1_DATE = new Date(2000, 0, 1);
+export const JAN_1_DATE_UTC = new Date(Date.UTC(2000, 0, 1));
 /** Tuesday */
 export const FEB_1 = dayjs('2000-02-01').utc(true);
 export const FEB_1_DATE = new Date(2000, 1, 1);
+export const FEB_1_DATE_UTC = new Date(Date.UTC(2000, 1, 1));
 /** Wednesday */
 export const MAR_1 = dayjs('2000-03-01').utc(true);
 export const MAR_1_DATE = new Date(2000, 2, 1);
+export const MAR_1_DATE_UTC = new Date(Date.UTC(2000, 2, 1));
 /** Monday */
 export const MAY_1 = dayjs('2000-05-01').utc(true);
 export const MAY_1_DATE = new Date(2000, 4, 1);
+export const MAY_1_DATE_UTC = new Date(Date.UTC(2000, 4, 1));
 /** Tuesday */
 export const MAY_2 = dayjs('2000-05-02').utc(true);
 export const MAY_2_DATE = new Date(2000, 4, 2);
+export const MAY_2_DATE_UTC = new Date(Date.UTC(2000, 4, 2));
 /** Wednesday */
 export const MAY_3 = dayjs('2000-05-03').utc(true);
 export const MAY_3_DATE = new Date(2000, 4, 3);
+export const MAY_3_DATE_UTC = new Date(Date.UTC(2000, 4, 3));
 /** Thursday */
 export const MAY_4 = dayjs('2000-05-04').utc(true);
 export const MAY_4_DATE = new Date(2000, 4, 4);
+export const MAY_4_DATE_UTC = new Date(Date.UTC(2000, 4, 4));
 /** Friday */
 export const MAY_5 = dayjs('2000-05-05').utc(true);
 export const MAY_5_DATE = new Date(2000, 4, 5);
+export const MAY_5_DATE_UTC = new Date(Date.UTC(2000, 4, 5));
 /** Saturday */
 export const MAY_6 = dayjs('2000-05-06').utc(true);
 export const MAY_6_DATE = new Date(2000, 4, 6);
+export const MAY_6_DATE_UTC = new Date(Date.UTC(2000, 4, 6));
 /** Sunday */
 export const MAY_7 = dayjs('2000-05-07').utc(true);
 export const MAY_7_DATE = new Date(2000, 4, 7);
+export const MAY_7_DATE_UTC = new Date(Date.UTC(2000, 4, 7));
 /** Monday */
 export const MAY_8 = dayjs('2000-05-08').utc(true);
 export const MAY_8_DATE = new Date(2000, 4, 8);
+export const MAY_8_DATE_UTC = new Date(Date.UTC(2000, 4, 8));
 /** Sunday */
 export const MAY_14 = dayjs('2000-05-14').utc(true);
 export const MAY_14_DATE = new Date(2000, 4, 14);
+export const MAY_14_DATE_UTC = new Date(Date.UTC(2000, 4, 14));
 /** Thursday */
 export const JUN_1 = dayjs('2000-06-01').utc(true);
 export const JUN_1_DATE = new Date(2000, 5, 1);
+export const JUN_1_DATE_UTC = new Date(Date.UTC(2000, 5, 1));
 /** Saturday */
 export const JUL_1 = dayjs('2000-07-01').utc(true);
 export const JUL_1_DATE = new Date(2000, 6, 1);
+export const JUL_1_DATE_UTC = new Date(Date.UTC(2000, 6, 1));
 /** Friday */
 export const SEP_1 = dayjs('2000-09-01').utc(true);
 export const SEP_1_DATE = new Date(2000, 8, 1);
+export const SEP_1_DATE_UTC = new Date(Date.UTC(2000, 8, 1));
 /** Sunday */
 export const OCT_1 = dayjs('2000-10-01').utc(true);
 export const OCT_1_DATE = new Date(2000, 9, 1);
+export const OCT_1_DATE_UTC = new Date(Date.UTC(2000, 9, 1));
 /** Friday */
 export const DEC_1 = dayjs('2000-12-01').utc(true);
 export const DEC_1_DATE = new Date(2000, 11, 1);
+export const DEC_1_DATE_UTC = new Date(Date.UTC(2000, 11, 1));
 
 export const DEC_17 = dayjs('2000-12-17').utc(true);
 export const DEC_17_DATE = new Date(2000, 11, 17);
+export const DEC_17_DATE_UTC = new Date(Date.UTC(2000, 11, 17));
 
 export const DEC_31 = dayjs('2000-12-31').utc(true);
 export const DEC_31_DATE = new Date(2000, 11, 31);
+export const DEC_31_DATE_UTC = new Date(Date.UTC(2000, 11, 31));
 
 /* 2001 Dates */
 export const MAY_14_2001 = dayjs('2001-05-14').utc(true);
 export const MAY_14_2001_DATE = new Date(2001, 4, 14);
+export const MAY_14_2001_DATE_UTC = new Date(Date.UTC(2001, 4, 14));
 
 export const DEC_1_2001 = dayjs('2001-12-01').utc(true);
 export const DEC_1_2001_DATE = new Date(2001, 11, 1);
+export const DEC_1_2001_DATE_UTC = new Date(Date.UTC(2001, 11, 1));

--- a/src/utils/CalendarUtils.getDateArray.test.ts
+++ b/src/utils/CalendarUtils.getDateArray.test.ts
@@ -6,55 +6,84 @@ function getDateRangeInclusive(start: Date, end: Date) {
   const results = [];
   while (cur <= end) {
     results.push(cur);
-    cur = new Date(cur.getFullYear(), cur.getMonth(), cur.getDate() + 1);
+    cur = new Date(
+      Date.UTC(cur.getUTCFullYear(), cur.getUTCMonth(), cur.getUTCDate() + 1)
+    );
   }
   return results;
 }
 
 test('A month beginning and ending mid-week works properly', () => {
   // apr 30 - may 3
-  expect(getDateArray('en-us', Dates.MAY_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 3, 30), new Date(2000, 5, 3))
+  expect(getDateArray('en-us', Dates.MAY_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 3, 30)),
+      new Date(Date.UTC(2000, 5, 3))
+    )
   );
   // feb 27 - apr 1
-  expect(getDateArray('en-us', Dates.MAR_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 1, 27), new Date(2000, 3, 1))
+  expect(getDateArray('en-us', Dates.MAR_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 1, 27)),
+      new Date(Date.UTC(2000, 3, 1))
+    )
   );
   // feb 28 - apr 2
-  expect(getDateArray('fr-fr', Dates.MAR_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 1, 28), new Date(2000, 3, 2))
+  expect(getDateArray('fr-fr', Dates.MAR_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 1, 28)),
+      new Date(Date.UTC(2000, 3, 2))
+    )
   );
 });
 
 test('A month beginning at the end of the week works properly', () => {
   // jun 25 - aug 5
-  expect(getDateArray('en-us', Dates.JUL_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 5, 25), new Date(2000, 7, 5))
+  expect(getDateArray('en-us', Dates.JUL_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 5, 25)),
+      new Date(Date.UTC(2000, 7, 5))
+    )
   );
   // sep 25 - nov 5
-  expect(getDateArray('fr-fr', Dates.OCT_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 8, 25), new Date(2000, 10, 5))
+  expect(getDateArray('fr-fr', Dates.OCT_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 8, 25)),
+      new Date(Date.UTC(2000, 10, 5))
+    )
   );
 });
 
 test('A month starting at the beginning of a week works properly', () => {
   // sep 24 - nov 4
-  expect(getDateArray('en-us', Dates.OCT_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 8, 24), new Date(2000, 10, 4))
+  expect(getDateArray('en-us', Dates.OCT_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 8, 24)),
+      new Date(Date.UTC(2000, 10, 4))
+    )
   );
   // apr 24 - jun 4
-  expect(getDateArray('fr-fr', Dates.MAY_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 3, 24), new Date(2000, 5, 4))
+  expect(getDateArray('fr-fr', Dates.MAY_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 3, 24)),
+      new Date(Date.UTC(2000, 5, 4))
+    )
   );
 });
 
 test('A month ending at the end of a week works properly', () => {
   // aug 27 - oct 7
-  expect(getDateArray('en-us', Dates.SEP_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 7, 27), new Date(2000, 9, 7))
+  expect(getDateArray('en-us', Dates.SEP_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 7, 27)),
+      new Date(Date.UTC(2000, 9, 7))
+    )
   );
   // oct 27 - jan 7
-  expect(getDateArray('fr-fr', Dates.DEC_1_DATE)).toStrictEqual(
-    getDateRangeInclusive(new Date(2000, 10, 27), new Date(2001, 0, 7))
+  expect(getDateArray('fr-fr', Dates.DEC_1_DATE_UTC)).toStrictEqual(
+    getDateRangeInclusive(
+      new Date(Date.UTC(2000, 10, 27)),
+      new Date(Date.UTC(2001, 0, 7))
+    )
   );
 });

--- a/src/utils/CalendarUtils.ts
+++ b/src/utils/CalendarUtils.ts
@@ -11,7 +11,7 @@ import {
   dateFromYYYYMMDD,
   dateFromYYYYMMDDAndHHMM,
   dateToTimeOnly,
-  isSameMonthOrBefore
+  isSameUTCMonthOrBefore
 } from './DateUtils';
 import { getFirstDayOfWeek, weekdayIsBetween, WEEKDAYS } from './WeekdayUtils';
 
@@ -236,16 +236,20 @@ export function isOpen247(openings: CalendarOpening[]): boolean {
 export const getDateArray = memoizee(
   (locale: string, monthBasis: Date): Date[] => {
     // start of the month
-    const date = new Date(monthBasis.getFullYear(), monthBasis.getMonth(), 1);
+    const date = new Date(
+      Date.UTC(monthBasis.getUTCFullYear(), monthBasis.getUTCMonth(), 1)
+    );
     // if the month starts at the beginning of the week, add a full row above of the previous month
-    if (date.getDay() === getFirstDayOfWeek(locale)) {
-      date.setDate(date.getDate() - 7);
+    if (date.getUTCDay() === getFirstDayOfWeek(locale)) {
+      date.setUTCDate(date.getUTCDate() - 7);
     }
 
     const firstWeekday = getFirstDayOfWeek(locale);
 
     // ensure startDate starts at the beginning of a week
-    date.setDate(date.getDate() - ((date.getDay() - firstWeekday + 7) % 7));
+    date.setUTCDate(
+      date.getUTCDate() - ((date.getUTCDay() - firstWeekday + 7) % 7)
+    );
 
     // at this point, date must be in a month before `month`.
 
@@ -254,16 +258,16 @@ export const getDateArray = memoizee(
     let week = [];
     do {
       week.push(new Date(date));
-      date.setDate(date.getDate() + 1);
+      date.setUTCDate(date.getUTCDate() + 1);
       if (week.length === 7) {
         displayDates.push(...week);
         week = [];
       }
-    } while (isSameMonthOrBefore(date, monthBasis));
+    } while (isSameUTCMonthOrBefore(date, monthBasis));
 
     while (week.length < 7) {
       week.push(new Date(date));
-      date.setDate(date.getDate() + 1);
+      date.setUTCDate(date.getUTCDate() + 1);
     }
     displayDates.push(...week);
 

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -85,6 +85,15 @@ export function getRelativeDateProximity(
 }
 
 /** Ensure a <= b, based on months */
+export function isSameUTCMonthOrBefore(a: Date, b: Date): boolean {
+  return (
+    (a.getUTCFullYear() === b.getUTCFullYear() &&
+      a.getUTCMonth() <= b.getUTCMonth()) ||
+    a.getUTCFullYear() < b.getUTCFullYear()
+  );
+}
+
+/** Ensure a <= b, based on months */
 export function isSameMonthOrBefore(a: Date, b: Date): boolean {
   return (
     (a.getFullYear() === b.getFullYear() && a.getMonth() <= b.getMonth()) ||
@@ -95,6 +104,22 @@ export function isSameMonthOrBefore(a: Date, b: Date): boolean {
 /** Ensure a == b, based on months */
 export function isSameMonth(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+/** Ensure a == b, based on months */
+export function isSameUTCMonth(a: Date, b: Date): boolean {
+  return (
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth()
+  );
+}
+
+export function dateUTCToYYYYMMDD(d: Date): string {
+  return [
+    d.getUTCFullYear(),
+    ('0' + (d.getUTCMonth() + 1)).slice(-2),
+    ('0' + d.getUTCDate()).slice(-2)
+  ].join('-');
 }
 
 export function dateToYYYYMMDD(d: Date): string {

--- a/src/views/MonthlyCalendarPickerView.tsx
+++ b/src/views/MonthlyCalendarPickerView.tsx
@@ -21,7 +21,7 @@ import css from '../components/Calendar.css';
 import useDataRepository from '../data/useDataRepository';
 import { DailyOpeningInfo } from '../types/types';
 import {
-  dateToYYYYMMDD,
+  dateUTCToYYYYMMDD,
   getDateRange,
   getLocalizedTime
 } from '../utils/DateUtils';
@@ -121,7 +121,7 @@ const MonthlyCalendarPickerView: FunctionComponent<
           loadingEvents[servicePointId] = {};
         }
         getDateRange(startDate, endDate).forEach((date) => {
-          loadingEvents[servicePointId][dateToYYYYMMDD(date)] = <Loading />;
+          loadingEvents[servicePointId][dateUTCToYYYYMMDD(date)] = <Loading />;
         });
         // prevents further calls of this function while these events are being loaded
         setEvents(loadingEvents);

--- a/src/views/panes/MonthlyCalendarView.tsx
+++ b/src/views/panes/MonthlyCalendarView.tsx
@@ -9,7 +9,7 @@ import { useIntl } from 'react-intl';
 import Calendar from '../../components/Calendar';
 import { ServicePoint } from '../../types/types';
 import { getDateArray } from '../../utils/CalendarUtils';
-import { dateToYYYYMMDD } from '../../utils/DateUtils';
+import { dateUTCToYYYYMMDD } from '../../utils/DateUtils';
 import { useLocaleWeekdays } from '../../utils/WeekdayUtils';
 
 interface MonthlyCalendarViewProps {
@@ -32,7 +32,7 @@ export const MonthlyCalendarView: FunctionComponent<
   requestEvents
 }: MonthlyCalendarViewProps) => {
   const [monthBasis, setMonthBasis] = useState(
-    new Date(new Date().getFullYear(), new Date().getMonth(), 1)
+    new Date(Date.UTC(new Date().getFullYear(), new Date().getMonth(), 1))
   ); // start at current date
   const intl = useIntl();
   const localeWeekdays = useLocaleWeekdays(intl);
@@ -53,7 +53,7 @@ export const MonthlyCalendarView: FunctionComponent<
       }
 
       const missingDates = dateArray.map(
-        (date) => !(dateToYYYYMMDD(date) in events)
+        (date) => !(dateUTCToYYYYMMDD(date) in events)
       );
       const rangeStartIndex = missingDates.indexOf(true);
       // none missing


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/UICAL/issues/UICAL-205)

This PR fixes off-by-one errors with the monthly calendar view.  For some timezones, the current month was incorrectly calculated (and events were shown off-by-one).  Additionally, the day numbers and shading were potentially also shifted by one.

This was fixed by ensuring UTC was used for all calculations, for consistency.