### PR TITLE
Fix stripes-testing version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change history for ui-calendar
 
+## [8.0.1] (https://github.com/folio-org/ui-calendar/tree/v8.0.1) (2022-11-07)
+
+* Use replacement permission syntax for automatic permission carryover. Refs UICAL-247
+* Fix end date column sorting in Current Assignment View. Refs UICAL-246
+* Add initial Cypress tests and infrastructure. Refs UICAL-249.
+* Fix timepicker timezone miscalculations. Refs UICAL-251
+* Allow more than ten service points to be chosen from. Refs UICAL-248
+* Fix monthly date view calculations. Refs UICAL-205
+
 ## [8.0.0] (https://github.com/folio-org/ui-calendar/tree/v8.0.0) (2022-10-27)
 
 * Rewrite module in TypeScript

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@folio/stripes-final-form": "^6.1.0",
     "@folio/stripes-form": "^7.1.0",
     "@folio/stripes-smart-components": "^7.2.0",
-    "@folio/stripes-testing": "^4.4.1",
+    "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.21",
     "@interactors/html": "^1.0.0-rc1.4",
     "@interactors/with-cypress": "^1.0.0-rc1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {


### PR DESCRIPTION
`stripes-testing` was on an incorrect (CI) version for development usage; this fixes the version to be ready for release.