### PR TITLE
Release v8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## [8.0.2] (https://github.com/folio-org/ui-calendar/tree/v8.0.2) (2022-11-07)
+
+* Fix stripes-testing version to non-CI version.
+
 ## [8.0.1] (https://github.com/folio-org/ui-calendar/tree/v8.0.1) (2022-11-07)
 
 * Use replacement permission syntax for automatic permission carryover. Refs UICAL-247

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {


### PR DESCRIPTION
Released v8.0.2 to include non-CI stripes-testing version (refs #456)