### PR TITLE
UICAL-262: Fix over-aggressive validation of timepicker responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## [8.0.3] (https://github.com/folio-org/ui-calendar/tree/v8.0.3) (2023-02-15)
+
+* Fix over-aggressive validation of timepicker inputs. Refs UICAL-262
+
 ## [8.0.2] (https://github.com/folio-org/ui-calendar/tree/v8.0.2) (2022-11-07)
 
 * Fix stripes-testing version to non-CI version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {

--- a/src/forms/CalendarForm/validation/validateDateTime.isTimeProper.test.ts
+++ b/src/forms/CalendarForm/validation/validateDateTime.isTimeProper.test.ts
@@ -25,6 +25,8 @@ test('Proper 12-hour time values returns true', () => {
   expect(isTimeProper(localeTimeFormat12, '13:30:00', '1:30 PM')).toBe(true);
   expect(isTimeProper(localeTimeFormat12, '13:30', '01:30 PM')).toBe(true);
   expect(isTimeProper(localeTimeFormat12, '13:30:00', '01:30 PM')).toBe(true);
+  expect(isTimeProper(localeTimeFormat12, '13:30', '13:30')).toBe(true);
+  expect(isTimeProper(localeTimeFormat12, '03:30', '03:30')).toBe(true);
   expect(isTimeProper(localeTimeFormat12, '03:30', '03:30 AM')).toBe(true);
   expect(isTimeProper(localeTimeFormat12, '03:30', '3:30 AM')).toBe(true);
   expect(isTimeProper(localeTimeFormat12, '3:30', '03:30 AM')).toBe(true);
@@ -44,13 +46,12 @@ test('Invalid 24-hour time values returns false', () => {
   expect(isTimeProper(localeTimeFormat24, '13:30', 'foo')).toBe(false);
   expect(isTimeProper(localeTimeFormat24, '03:30', '25:29')).toBe(false);
   expect(isTimeProper(localeTimeFormat24, '03:30', '3:61')).toBe(false);
-  expect(isTimeProper(localeTimeFormat24, '3:30', '03:30 AM')).toBe(false);
   expect(isTimeProper(localeTimeFormat24, '3:30', '15:30')).toBe(false);
   expect(isTimeProper(localeTimeFormat24, '3:30', '2:20')).toBe(false);
   expect(isTimeProper(localeTimeFormat24, '3:30', '23:20')).toBe(false);
 });
 
-test('Invalid 12-hour time values returns true', () => {
+test('Invalid 12-hour time values returns false', () => {
   expect(isTimeProper(localeTimeFormat12, '13:30', '')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '13:30', 'foo')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '13:30', '13:30')).toBe(false);

--- a/src/forms/CalendarForm/validation/validateDateTime.isTimeProper.test.ts
+++ b/src/forms/CalendarForm/validation/validateDateTime.isTimeProper.test.ts
@@ -54,7 +54,6 @@ test('Invalid 24-hour time values returns false', () => {
 test('Invalid 12-hour time values returns false', () => {
   expect(isTimeProper(localeTimeFormat12, '13:30', '')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '13:30', 'foo')).toBe(false);
-  expect(isTimeProper(localeTimeFormat12, '13:30', '13:30')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '13:30', '13:30 AM')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '03:30', '25:29')).toBe(false);
   expect(isTimeProper(localeTimeFormat12, '03:30', '3:61')).toBe(false);

--- a/src/forms/CalendarForm/validation/validateDateTime.tsx
+++ b/src/forms/CalendarForm/validation/validateDateTime.tsx
@@ -14,6 +14,9 @@ export function isTimeProper(
   }
 
   let timeObject = dayjs(realInputValue, localeTimeFormat, true);
+  if (!timeObject.isValid() && realInputValue.length <= 5) {
+    timeObject = dayjs(realInputValue, 'HH:mm');
+  }
   if (!timeObject.isValid()) {
     // the picker has a tendency to remove leading zeroes
     timeObject = dayjs(


### PR DESCRIPTION
# [UICAL-262](https://issues.folio.org/browse/UICAL-262)

## Purpose
Bug fix for an issue reported in Nolana bugfest; similar to #469 but based on the old timepicker code.

## Approach
This relaxes the constraints on what shape the timepicker value should be, since it can vary heavily depending on user locale/input method.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
