### PR TITLE
UICAL-261: Release v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change history for ui-calendar
 
+
+## [8.1.0] (https://github.com/folio-org/ui-calendar/tree/v8.0.3) (2023-02-17)
+
+* Refactor timepicker usage to reflect new component. Refs UICAL-261
+
+## [8.0.3] (https://github.com/folio-org/ui-calendar/tree/v8.0.3) (2023-02-15)
+
+* Fix over-aggressive validation of timepicker inputs. Refs UICAL-262
+
 ## [8.0.2] (https://github.com/folio-org/ui-calendar/tree/v8.0.2) (2022-11-07)
 
 * Fix stripes-testing version to non-CI version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {


### PR DESCRIPTION
Release v8.1.0, as part of [UICAL-259](https://issues.folio.org/browse/UICAL-259)