### PR TITLE
UICAL-259: Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {
@@ -163,7 +163,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "final-form": "^4.20.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/UICAL/issues/UICAL-259)

Stripes v8 support was added in #469, however, the peer dependencies were not properly updated.  This PR fixes the peer dep and will be released in v9.0, to be consistent with semantic versioning.