### PR TITLE
UICAL-262: Fix timepicker w.r.t. Chrome 110 spacing

### DIFF
--- a/src/components/fields/ExceptionFieldUtils.tsx
+++ b/src/components/fields/ExceptionFieldUtils.tsx
@@ -210,7 +210,6 @@ export function getDateTimeFields({
         })}
         display={row.type === RowType.Open}
         value={innerRow.startTime}
-        localeTimeFormat={props.localeTimeFormat}
         inputRef={(el) => {
           fieldRefs.startTime[row.i][innerRow.i] = el;
         }}
@@ -262,7 +261,6 @@ export function getDateTimeFields({
         })}
         display={row.type === RowType.Open}
         value={innerRow.endTime}
-        localeTimeFormat={props.localeTimeFormat}
         inputRef={(el) => {
           fieldRefs.endTime[row.i][innerRow.i] = el;
         }}

--- a/src/components/fields/HoursOfOperationField.test.tsx
+++ b/src/components/fields/HoursOfOperationField.test.tsx
@@ -143,7 +143,6 @@ describe('HoursOfOperationField', () => {
         <HoursOfOperationField
           timeFieldRefs={{ startTime: {}, endTime: {} }}
           error={undefined}
-          localeTimeFormat="HH:mm a"
           submitAttempted={false}
           input={{
             name: 'exception-field',

--- a/src/components/fields/HoursOfOperationField.tsx
+++ b/src/components/fields/HoursOfOperationField.tsx
@@ -50,7 +50,6 @@ export interface HoursOfOperationFieldProps
   extends FieldRenderProps<HoursOfOperationRowState[]> {
   timeFieldRefs: InnerFieldRefs['hoursOfOperation'];
   error?: HoursOfOperationErrors;
-  localeTimeFormat: string;
   submitAttempted: boolean;
   isNewCalendar: boolean;
 }
@@ -140,7 +139,6 @@ export const HoursOfOperationField: FunctionComponent<
           <TimeField
             display={row.type === RowType.Open}
             value={row.startTime}
-            localeTimeFormat={props.localeTimeFormat}
             inputRef={(el) => {
               props.timeFieldRefs.startTime[row.i] = el;
             }}
@@ -183,7 +181,6 @@ export const HoursOfOperationField: FunctionComponent<
           <TimeField
             display={row.type === RowType.Open}
             value={row.endTime}
-            localeTimeFormat={props.localeTimeFormat}
             inputRef={(el) => {
               props.timeFieldRefs.endTime[row.i] = el;
             }}

--- a/src/components/fields/TimeField.tsx
+++ b/src/components/fields/TimeField.tsx
@@ -1,7 +1,6 @@
 import { Timepicker } from '@folio/stripes/components';
 import classNames from 'classnames';
 import React, { ReactNode, useState } from 'react';
-import dayjs from '../../utils/dayjs';
 import css from './hiddenErrorField.css';
 
 function noOp() {
@@ -12,7 +11,6 @@ export interface TimeFieldProps {
   display: boolean;
   value: string | undefined;
   inputRef: (el: HTMLInputElement) => void;
-  localeTimeFormat: string;
   error: ReactNode;
   onBlur: () => void;
   onChange: (newValue: string | undefined) => void;
@@ -23,7 +21,6 @@ export default function TimeField({
   value,
   display,
   inputRef,
-  localeTimeFormat,
   error,
   onBlur,
   className,
@@ -45,17 +42,18 @@ export default function TimeField({
           name: '',
           onBlur: noOp,
           onFocus: noOp,
-          onChange: (newTime: string) => {
+          onChange: (newTimeWithWeirdSpace: string) => {
+            const newTime = newTimeWithWeirdSpace.replaceAll('\u202f', ' ');
             const input = internalRef;
             if (input !== null) {
               const selection = input.selectionStart;
-              input.value = dayjs(newTime, 'HH:mm').format(localeTimeFormat);
+              input.value = newTime;
               input.setSelectionRange(selection, selection);
             }
             props.onChange(
               newTime.length ? newTime.substring(0, 5) : undefined
             );
-          }
+          },
         }}
         // always fires, compared to input.onChange
         onChange={() => onBlur()}
@@ -67,7 +65,7 @@ export default function TimeField({
         usePortal
         meta={{
           touched: true,
-          error
+          error,
         }}
         timeZone="UTC"
       />

--- a/src/forms/CalendarForm/CalendarForm.tsx
+++ b/src/forms/CalendarForm/CalendarForm.tsx
@@ -74,7 +74,9 @@ export const CreateCalendarForm: FunctionComponent<CreateCalendarFormProps> = (
   );
 
   const localeDateFormat = getLocaleDateFormat({ intl });
-  const localeTimeFormat = getLocalizedTimeFormatInfo(intl.locale).timeFormat;
+  const localeTimeFormat = getLocalizedTimeFormatInfo(
+    intl.locale
+  ).timeFormat.replaceAll('\u202f', ' ');
 
   const startDateRef = useRef<HTMLInputElement>(null);
   const endDateRef = useRef<HTMLInputElement>(null);
@@ -216,7 +218,6 @@ export const CreateCalendarForm: FunctionComponent<CreateCalendarFormProps> = (
                   component={HoursOfOperationField}
                   timeFieldRefs={innerFieldRefs.current.hoursOfOperation}
                   error={errors?.['hours-of-operation']}
-                  localeTimeFormat={localeTimeFormat}
                   submitAttempted={props.submitAttempted}
                   isNewCalendar={props.initialValues === undefined}
                 />
@@ -231,7 +232,6 @@ export const CreateCalendarForm: FunctionComponent<CreateCalendarFormProps> = (
                   component={ExceptionField}
                   fieldRefs={innerFieldRefs.current.exceptions}
                   error={errors?.exceptions}
-                  localeTimeFormat={localeTimeFormat}
                   submitAttempted={props.submitAttempted}
                 />
               </Accordion>

--- a/src/forms/CalendarForm/types.ts
+++ b/src/forms/CalendarForm/types.ts
@@ -32,9 +32,6 @@ export interface ExceptionFieldProps
   extends FieldRenderProps<ExceptionRowState[]> {
   fieldRefs: InnerFieldRefs['exceptions'];
   error?: ExceptionFieldErrors;
-  // used in getDateTimeFields
-  // eslint-disable-next-line react/no-unused-prop-types
-  localeTimeFormat: string;
   submitAttempted: boolean;
 }
 

--- a/src/forms/CalendarForm/validation/validateDateTime.tsx
+++ b/src/forms/CalendarForm/validation/validateDateTime.tsx
@@ -18,6 +18,14 @@ export function isTimeProper(
     timeObject = dayjs(realInputValue, 'HH:mm');
   }
   if (!timeObject.isValid()) {
+    // attempt parsing value from timepicker (it returns ISO format sometimes)
+    timeObject = dayjs(
+      realInputValue,
+      'HH:mm:ss.SSS[Z]',
+      true
+    );
+  }
+  if (!timeObject.isValid()) {
     // the picker has a tendency to remove leading zeroes
     timeObject = dayjs(
       realInputValue,

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -211,7 +211,7 @@ export function getLocalizedTime(intl: IntlShape, time: string): string {
     return intl.formatMessage({ id: 'ui-calendar.midnight' });
   }
 
-  return intl.formatTime(date, { timeZone: 'UTC' });
+  return intl.formatTime(date, { timeZone: 'UTC' }).replaceAll('\u202f', ' ');
 }
 
 /** Localize date with `react-intl` */

--- a/src/views/MonthlyCalendarPickerView.test.js
+++ b/src/views/MonthlyCalendarPickerView.test.js
@@ -7,7 +7,6 @@ import withHistoryConfiguration from '../test/util/withHistoryConfiguration';
 import ServicePoints from '../test/data/ServicePoints';
 import MonthlyCalendarPickerView, { dailyOpeningToCalendarDisplay } from './MonthlyCalendarPickerView';
 import * as Dates from '../test/data/Dates';
-import * as Times from '../test/data/DateTimes';
 
 jest.mock('../data/useDataRepository');
 jest.mock('../components/Calendar.tsx', () => {


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/UICAL/issues/UICAL-262)

## Purpose
In Chrome v110, the intl `formatTime` method will insert narrow non-breaking spaces into times rather than the typical space character; this broke some of the parsing this module did to validate inputs and take advantage of the stripes-components Timepicker.

## Approach
This was primarily resolved by ensuring the new space character was replaced with the standard ASCII space.

## Notes
This is for Nolana only, not Orchid.  In Orchid, the Timepicker was largely refactored (see #469).