### PR TITLE
Prepare for next development iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 * Refactor timepicker usage to reflect new component. Refs UICAL-261
 
+## [8.0.4] (https://github.com/folio-org/ui-calendar/tree/v8.0.4) (2023-02-28)
+
+* Fix Chrome v110 time formatting changes. Refs UICAL-262
+
 ## [8.0.3] (https://github.com/folio-org/ui-calendar/tree/v8.0.3) (2023-02-15)
 
 * Fix over-aggressive validation of timepicker inputs. Refs UICAL-262

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/calendar",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Calendar settings",
   "repository": "folio-org/ui-calendar",
   "publishConfig": {


### PR DESCRIPTION
This updates the next version to `9.2.0` and adds the changelog for `8.0.4`