### PR TITLE
UICAL-266: Update eslint to ignore typings files and allow any in unit tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["@folio/eslint-config-stripes", "plugin:import/typescript"],
+  "ignorePatterns": ["src/typings/**/*.d.ts"],
   "env": {
     "jest": true
   },
@@ -9,7 +10,10 @@
   "overrides": [
     {
       "files": ["src/test/**/*", "src/**/*.test.ts", "src/**/*.test.tsx"],
-      "env": { "jest": true }
+      "env": { "jest": true },
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
     }
   ]
 }


### PR DESCRIPTION
# [Jira](https://issues.folio.org/browse/UICAL-266)

## Purpose
This adds eslint configuration to ignore type declaration files (`.d.ts`) and allow unit tests to use `any`.
