### PR TITLE
[UICAL-279] Remove explicit typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,8 +132,7 @@
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.7",
     "react-router-dom": "^5.2.0",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.2.2"
+    "ts-jest": "^29.1.1"
   },
   "dependencies": {
     "@types/memoizee": "^0.4.8",


### PR DESCRIPTION
# [Jira UICAL-279](https://issues.folio.org/browse/UICAL-279)

As part of [Jira STRIPES-900](https://issues.folio.org/browse/STRIPES-900), all modules should use one `typescript` version, inherited from `@folio/stripes-webpack`.  Therefore, the explicit `typescript` version in this `package.json` should be removed.