### PR TITLE
UICAL-283: Address empty fourth pane on open of 'Current calendar assignment'

### DIFF
--- a/src/views/CurrentAssignmentView.tsx
+++ b/src/views/CurrentAssignmentView.tsx
@@ -35,7 +35,7 @@ export const CurrentAssignmentView: FunctionComponent<
   const history = useHistory();
   const currentRouteId = useRouteMatch<{ servicePointId: string }>(
     '/settings/calendar/active/:servicePointId'
-  )?.params?.servicePointId ?? '';
+  )?.params?.servicePointId;
 
   if (!dataRepository.isLoaded()) {
     return (
@@ -93,7 +93,7 @@ export const CurrentAssignmentView: FunctionComponent<
     };
   });
 
-  const calendarName = dataRepository.getCalendars().filter((c) => c.assignments.includes(currentRouteId))[0]?.name ?? '';
+  const calendarName = dataRepository.getCalendars().filter((c) => c.assignments.includes(currentRouteId ?? ''))[0]?.name ?? '';
 
   const pageTitle = intl.formatMessage({ id: 'ui-calendar.meta.titleSettings' }) + ' - ' + intl.formatMessage({
     id: 'ui-calendar.currentAssignmentView.title'


### PR DESCRIPTION
Per [UICAL-283](https://folio-org.atlassian.net/jira/software/c/projects/UICAL/issues/UICAL-283?jql=project%20%3D%20%22UICAL%22%20ORDER%20BY%20created%20DESC), initialize route ID to undefined, not ''. This is how the `currentRouteId` is initialized in the `MonthlyCalendarPickerView`. Image shown below detailing changes.

`''` ===`undefined` doesn't not execute as `true`.

<img width="1092" alt="Screenshot 2024-04-30 at 4 22 22 PM" src="https://github.com/folio-org/ui-calendar/assets/97154067/ba9d26a4-3a26-4bfc-88fc-7834ff404f79">
