### PR TITLE
UICAL-284 lock memoizee to v0.4.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "fuzzysort": "^2.0.4",
     "history": "^4.7.11",
     "ky": "^0.31.1",
-    "memoizee": "^0.4.15",
+    "memoizee": "0.4.15",
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.4",
     "utility-types": "^3.10.0"


### PR DESCRIPTION
Lock `memoizee` to `v0.4.15` to avoid the broken `engines.node` version string in `v0.4.16`. This should be unlocked at a later date when the bug is corrected.

Refs [UICAL-284](https://folio-org.atlassian.net/browse/UICAL-284)
