### PR TITLE
UICAL-285 - Disable 'Actions' menu on DCB Calendar.

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -151,7 +151,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -159,7 +159,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -90,7 +90,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -98,7 +98,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-calendar
 
+## In progress
+
+* Disable 'Actions' menu on DCB Calendar. Refs UICAL-285.
+
 ## [11.0.1] (https://github.com/folio-org/ui-calendar/tree/v11.0.1) (2024-05-08)
 
 * Address empty fourth pane on open of 'Current calendar assignment'. Refs UICAL-283

--- a/src/test/data/Calendars.ts
+++ b/src/test/data/Calendars.ts
@@ -229,11 +229,11 @@ export const SUMMER_SP_4_245: CalendarDTO = {
 };
 
 export const DCB: CalendarDTO = {
-  id: "f3fde29e-59f7-47a6-8109-af6cb92acde5",
-  name:  "DCB Calendar",
-  assignments: ["9d1b77e8-f02e-4b7f-b296-3f2042ddac54"],
+  id: 'f3fde29e-59f7-47a6-8109-af6cb92acde5',
+  name:  'DCB Calendar',
+  assignments: ['9d1b77e8-f02e-4b7f-b296-3f2042ddac54'],
   startDate: '2000-01-01',
   endDate: '2000-04-30',
   normalHours: [],
   exceptions: []
-}
+};

--- a/src/test/data/Calendars.ts
+++ b/src/test/data/Calendars.ts
@@ -227,3 +227,13 @@ export const SUMMER_SP_4_245: CalendarDTO = {
   ],
   exceptions: []
 };
+
+export const DCB: CalendarDTO = {
+  id: "f3fde29e-59f7-47a6-8109-af6cb92acde5",
+  name:  "DCB Calendar",
+  assignments: ["9d1b77e8-f02e-4b7f-b296-3f2042ddac54"],
+  startDate: '2000-01-01',
+  endDate: '2000-04-30',
+  normalHours: [],
+  exceptions: []
+}

--- a/src/views/panes/InfoPane.test.tsx
+++ b/src/views/panes/InfoPane.test.tsx
@@ -285,6 +285,39 @@ describe('Calendar info pane', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
+  it('should not render action buttons for DCB calendar', async () => {
+    const props = {
+      creationBasePath: '',
+      editBasePath: '',
+      calendar: Calendars.DCB,
+      onClose: jest.fn(),
+      dataRepository: new DataRepository(undefined, undefined, {
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+        dates: jest.fn(),
+      }),
+    };
+
+    render(
+      withEverything(
+        <Paneset>
+          <InfoPane {...props} />
+        </Paneset>,
+      ),
+    );
+
+    // await act(async () => {
+    //   await userEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    // });
+
+    // expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    // expect(
+    //   screen.getByRole('button', { name: 'Duplicate' }),
+    // ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Actions' })).toBeNull();
+  });
+
   it.skip('handles delete', async () => {
     const props = {
       creationBasePath: '',

--- a/src/views/panes/InfoPane.test.tsx
+++ b/src/views/panes/InfoPane.test.tsx
@@ -307,14 +307,6 @@ describe('Calendar info pane', () => {
       ),
     );
 
-    // await act(async () => {
-    //   await userEvent.click(screen.getByRole('button', { name: 'Actions' }));
-    // });
-
-    // expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    // expect(
-    //   screen.getByRole('button', { name: 'Duplicate' }),
-    // ).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Actions' })).toBeNull();
   });
 

--- a/src/views/panes/InfoPane.tsx
+++ b/src/views/panes/InfoPane.tsx
@@ -33,6 +33,7 @@ import ifPermissionOr from '../../utils/ifPermissionOr';
 import css from './InfoPane.css';
 
 const DCB_CALENDAR = 'DCB Calendar';
+
 export interface InfoPaneProps {
   creationBasePath: string;
   editBasePath: string;

--- a/src/views/panes/InfoPane.tsx
+++ b/src/views/panes/InfoPane.tsx
@@ -120,6 +120,9 @@ export const InfoPane: FunctionComponent<InfoPaneProps> = (
         onClose={props.onClose}
         dismissible
         actionMenu={({ onToggle }) => {
+          if ( calendar.name === 'DCB Calendar') {
+            return null;
+          }
           return ifPermissionOr(
             stripes,
             [permissions.UPDATE, permissions.CREATE, permissions.DELETE],

--- a/src/views/panes/InfoPane.tsx
+++ b/src/views/panes/InfoPane.tsx
@@ -32,6 +32,7 @@ import { generateExceptionalOpeningRows } from '../../utils/InfoPaneUtils';
 import ifPermissionOr from '../../utils/ifPermissionOr';
 import css from './InfoPane.css';
 
+const DCB_CALENDAR = 'DCB Calendar';
 export interface InfoPaneProps {
   creationBasePath: string;
   editBasePath: string;
@@ -120,7 +121,7 @@ export const InfoPane: FunctionComponent<InfoPaneProps> = (
         onClose={props.onClose}
         dismissible
         actionMenu={({ onToggle }) => {
-          if ( calendar.name === 'DCB Calendar') {
+          if (calendar.name === DCB_CALENDAR) {
             return null;
           }
           return ifPermissionOr(


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to the reviewer and future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->
UICAL-285 - Disable editing of DCB calendar

@folio-org/fe-tl-reviewers  @ncovercash  Kindly review this PR with priority as it is needed for Q CSP#5.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but also to help other
 developers *work* with your solution in the future.
-->
DCB transactions are associated with an umbrella calendar hardcoded in BE as "DCB Calendar".
The actions menu for this DCB Calendar is supposed to be hidden i.e., editing DCB Calendar is forbidden from UI.

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICAL-136
-->
https://folio-org.atlassian.net/browse/UICAL-285
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect* opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
