### PR TITLE
Specify explicit return types in ambiguous case

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-calendar ./translations/ui-calendar/compiled"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0.0",
+    "@folio/eslint-config-stripes": "^7.2.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-cli": "^3.0.0",
     "@formatjs/cli": "^6.2.0",
@@ -158,5 +158,8 @@
     "react-intl": "^6.4.4",
     "react-query": "^3.39.2",
     "react-router-dom": "^5.2.0"
+  },
+  "resolutions": {
+    "@types/react": "^18.3.14"
   }
 }

--- a/src/views/CurrentAssignmentView.tsx
+++ b/src/views/CurrentAssignmentView.tsx
@@ -12,7 +12,7 @@ import {
 import SortableMultiColumnList from '../components/SortableMultiColumnList';
 import useDataRepository from '../data/useDataRepository';
 import permissions from '../types/permissions';
-import { Calendar } from '../types/types';
+import { Calendar, CalendarDTO } from '../types/types';
 import {
   dateFromYYYYMMDD,
   getLocalizedDate,
@@ -47,7 +47,17 @@ export const CurrentAssignmentView: FunctionComponent<
     );
   }
 
-  const rows = dataRepository.getServicePoints().map((servicePoint) => {
+  const rows = dataRepository.getServicePoints().map((servicePoint): {
+    servicePoint: string;
+    servicePointId: string;
+    calendarName: ReactNode;
+    startDate: ReactNode;
+    startDateObj?: Date;
+    endDate: ReactNode;
+    endDateObj?: Date;
+    currentStatus: string;
+    calendar: CalendarDTO | null;
+  } => {
     const calendars = dataRepository.getCalendars().filter((calendar) => {
       return (
         isBetweenDatesByDay(
@@ -57,6 +67,7 @@ export const CurrentAssignmentView: FunctionComponent<
         ) && calendar.assignments.includes(servicePoint.id)
       );
     });
+
     if (calendars.length === 0) {
       return {
         servicePoint: servicePoint.name.concat(


### PR DESCRIPTION
The typing ambiguity here between the different returns caused some build problems with newer `eslint` versions.