### PR TITLE
[UICAL-294] Return to service point view after editing

### DIFF
--- a/src/forms/CalendarForm/CalendarForm.test.tsx
+++ b/src/forms/CalendarForm/CalendarForm.test.tsx
@@ -5,6 +5,7 @@ import withIntlConfiguration from '../../test/util/withIntlConfiguration';
 import CreateCalendarForm from './CalendarForm';
 import DataRepository from '../../data/DataRepository';
 import * as ServicePoints from '../../test/data/ServicePoints';
+import withHistoryConfiguration from '../../test/util/withHistoryConfiguration';
 
 
 // eslint-disable-next-line func-names
@@ -34,8 +35,10 @@ describe('CreateCalendarForm', () => {
     const submitter = jest.fn();
     it('renders', () => {
       render(
-        withIntlConfiguration(
-          <CreateCalendarForm closeParentLayer={closeParentLayer} dataRepository={dataRepository} submitAttempted setIsSubmitting={setIsSubmitting} submitter={submitter} />
+        withHistoryConfiguration(
+          withIntlConfiguration(
+            <CreateCalendarForm closeParentLayer={closeParentLayer} dataRepository={dataRepository} submitAttempted setIsSubmitting={setIsSubmitting} submitter={submitter} />
+          )
         )
       );
       expect(screen.getByText('Calendar name')).toBeInTheDocument();

--- a/src/forms/CalendarForm/CalendarForm.tsx
+++ b/src/forms/CalendarForm/CalendarForm.tsx
@@ -12,10 +12,11 @@ import {
   TextField,
 } from '@folio/stripes/components';
 import { CalloutContext } from '@folio/stripes/core';
-import { FormApi, FORM_ERROR } from 'final-form';
+import { FORM_ERROR, FormApi } from 'final-form';
 import React, { FunctionComponent, useCallback, useContext, useMemo, useRef } from 'react';
 import { Field, Form } from 'react-final-form';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 import ExceptionField from '../../components/fields/ExceptionField';
 import css from '../../components/fields/HoursAndExceptionFields.css';
 import HoursOfOperationField from '../../components/fields/HoursOfOperationField';
@@ -44,6 +45,9 @@ export const CreateCalendarForm: FunctionComponent<CreateCalendarFormProps> = (
   const calloutContext = useContext(CalloutContext);
   const intl = useIntl();
 
+  // Parse the returnTo parameter from the URL
+  const returnTo = new URLSearchParams(useLocation().search).get('returnToServicePoint');
+
   const onSubmitCallback = useCallback(
     (values: FormValues, form: FormApi<FormValues>) => {
       return onSubmit(
@@ -57,9 +61,10 @@ export const CreateCalendarForm: FunctionComponent<CreateCalendarFormProps> = (
         intl,
         values,
         form,
+        returnTo,
       );
     },
-    [props, calloutContext, intl],
+    [props, calloutContext, intl, returnTo],
   );
 
   const localeDateFormat = getLocaleDateFormat({ intl });

--- a/src/forms/CalendarForm/onSubmit.tsx
+++ b/src/forms/CalendarForm/onSubmit.tsx
@@ -23,6 +23,7 @@ export default async function onSubmit(
 
   values: Optional<FormValues, 'service-points' | 'hours-of-operation' | 'exceptions'>,
   form: FormApi<FormValues>,
+  returnTo: string | null,
 ): Promise<SubmissionErrors> {
   if (form.getState().hasValidationErrors) {
     return undefined;
@@ -101,7 +102,7 @@ export default async function onSubmit(
   try {
     const cal = await props.submitter(newCalendar);
 
-    props.closeParentLayer(cal.id as string);
+    props.closeParentLayer(returnTo ?? cal.id as string);
   } catch (e) {
     const response = (e as HTTPError).response;
     const errors = (await response.json()) as ErrorResponse;

--- a/src/views/CurrentAssignmentView.tsx
+++ b/src/views/CurrentAssignmentView.tsx
@@ -221,8 +221,8 @@ export const CurrentAssignmentView: FunctionComponent<
                 dataRepository={dataRepository}
                 initialValue={dataRepository.getCalendar(match.params.id)}
                 isEdit
-                onClose={() => {
-                  history.push(`/settings/calendar/active/${match.params.id}`);
+                onClose={(returnToServicePoint?: string) => {
+                  history.push(`/settings/calendar/active/${returnToServicePoint ?? match.params.id}`);
                   showCreateLayerButtonRef.current?.focus();
                 }}
               />
@@ -241,6 +241,7 @@ export const CurrentAssignmentView: FunctionComponent<
                 ?.calendar
             }
             dataRepository={dataRepository}
+            returnToServicePointView={currentRouteId}
           />
         </Route>
       </Switch>

--- a/src/views/panes/InfoPane.tsx
+++ b/src/views/panes/InfoPane.tsx
@@ -40,6 +40,7 @@ export interface InfoPaneProps {
   calendar?: CalendarDTO | null;
   onClose: () => void;
   dataRepository: DataRepository;
+  returnToServicePointView?: string;
 }
 
 export const InfoPane: FunctionComponent<InfoPaneProps> = (
@@ -137,7 +138,11 @@ export const InfoPane: FunctionComponent<InfoPaneProps> = (
                 <Button
                   buttonStyle="dropdownItem"
                   onClick={onToggle}
-                  to={`${props.editBasePath}/${calendar.id}`}
+                  to={`${props.editBasePath}/${calendar.id}${
+                    props.returnToServicePointView
+                      ? `?returnToServicePoint=${props.returnToServicePointView}`
+                      : ''
+                  }`}
                 >
                   <Icon size="small" icon="edit">
                     <FormattedMessage id="stripes-core.button.edit" />


### PR DESCRIPTION
Previously, saving from the service point view would attempt to redirect to `/settings/calendar/active/{calendarId}`, however, this route expects the service point ID instead. This updates the redirect logic to redirect to the service point view whenever coming from the "Current calendar assignments" page.